### PR TITLE
compression=0, compressionType, backupVersionCode, allow replacement toybox in /data/local, return code with disableVerification

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,6 +33,8 @@ android {
         targetSdk = 32
         versionCode = 8000
         versionName = "8.0.0"
+        buildConfigField("int", "MAJOR", "$major")
+        buildConfigField("int","MINOR", "$minor")
 
         testApplicationId = "${applicationId}.tests"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/schemas/com.machiav3lli.backup.dbs.ODatabase/3.json
+++ b/app/schemas/com.machiav3lli.backup.dbs.ODatabase/3.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 3,
-    "identityHash": "a70a9cbba1c554cee53bafd0985708aa",
+    "identityHash": "89dc3d3d38e95d3da8c53adb041dd74f",
     "entities": [
       {
         "tableName": "Schedule",
@@ -340,8 +340,14 @@
       },
       {
         "tableName": "Backup",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageName` TEXT NOT NULL, `packageLabel` TEXT, `versionName` TEXT, `versionCode` INTEGER NOT NULL, `profileId` INTEGER NOT NULL, `sourceDir` TEXT, `splitSourceDirs` TEXT NOT NULL, `isSystem` INTEGER NOT NULL, `backupDate` TEXT NOT NULL, `hasApk` INTEGER NOT NULL, `hasAppData` INTEGER NOT NULL, `hasDevicesProtectedData` INTEGER NOT NULL, `hasExternalData` INTEGER NOT NULL, `hasObbData` INTEGER NOT NULL, `hasMediaData` INTEGER NOT NULL, `cipherType` TEXT, `iv` BLOB, `cpuArch` TEXT, `permissions` TEXT NOT NULL, PRIMARY KEY(`packageName`, `backupDate`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`backupVersionCode` INTEGER NOT NULL, `packageName` TEXT NOT NULL, `packageLabel` TEXT, `versionName` TEXT, `versionCode` INTEGER NOT NULL, `profileId` INTEGER NOT NULL, `sourceDir` TEXT, `splitSourceDirs` TEXT NOT NULL, `isSystem` INTEGER NOT NULL, `backupDate` TEXT NOT NULL, `hasApk` INTEGER NOT NULL, `hasAppData` INTEGER NOT NULL, `hasDevicesProtectedData` INTEGER NOT NULL, `hasExternalData` INTEGER NOT NULL, `hasObbData` INTEGER NOT NULL, `hasMediaData` INTEGER NOT NULL, `compressionType` TEXT, `cipherType` TEXT, `iv` BLOB, `cpuArch` TEXT, `permissions` TEXT NOT NULL, PRIMARY KEY(`packageName`, `backupDate`))",
         "fields": [
+          {
+            "fieldPath": "backupVersionCode",
+            "columnName": "backupVersionCode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
           {
             "fieldPath": "packageName",
             "columnName": "packageName",
@@ -433,6 +439,12 @@
             "notNull": true
           },
           {
+            "fieldPath": "compressionType",
+            "columnName": "compressionType",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
             "fieldPath": "cipherType",
             "columnName": "cipherType",
             "affinity": "TEXT",
@@ -471,7 +483,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a70a9cbba1c554cee53bafd0985708aa')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '89dc3d3d38e95d3da8c53adb041dd74f')"
     ]
   }
 }

--- a/app/schemas/com.machiav3lli.backup.dbs.ODatabase/4.json
+++ b/app/schemas/com.machiav3lli.backup.dbs.ODatabase/4.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 4,
-    "identityHash": "6eadb5138fe4dfb017171b5484f35cb6",
+    "identityHash": "41972af530623d54e335f87f2787aa67",
     "entities": [
       {
         "tableName": "Schedule",
@@ -340,8 +340,14 @@
       },
       {
         "tableName": "Backup",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`packageName` TEXT NOT NULL, `packageLabel` TEXT, `versionName` TEXT, `versionCode` INTEGER NOT NULL, `profileId` INTEGER NOT NULL, `sourceDir` TEXT, `splitSourceDirs` TEXT NOT NULL, `isSystem` INTEGER NOT NULL, `backupDate` TEXT NOT NULL, `hasApk` INTEGER NOT NULL, `hasAppData` INTEGER NOT NULL, `hasDevicesProtectedData` INTEGER NOT NULL, `hasExternalData` INTEGER NOT NULL, `hasObbData` INTEGER NOT NULL, `hasMediaData` INTEGER NOT NULL, `cipherType` TEXT, `iv` BLOB, `cpuArch` TEXT, `permissions` TEXT NOT NULL, PRIMARY KEY(`packageName`, `backupDate`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`backupVersionCode` INTEGER NOT NULL, `packageName` TEXT NOT NULL, `packageLabel` TEXT, `versionName` TEXT, `versionCode` INTEGER NOT NULL, `profileId` INTEGER NOT NULL, `sourceDir` TEXT, `splitSourceDirs` TEXT NOT NULL, `isSystem` INTEGER NOT NULL, `backupDate` TEXT NOT NULL, `hasApk` INTEGER NOT NULL, `hasAppData` INTEGER NOT NULL, `hasDevicesProtectedData` INTEGER NOT NULL, `hasExternalData` INTEGER NOT NULL, `hasObbData` INTEGER NOT NULL, `hasMediaData` INTEGER NOT NULL, `compressionType` TEXT, `cipherType` TEXT, `iv` BLOB, `cpuArch` TEXT, `permissions` TEXT NOT NULL, PRIMARY KEY(`packageName`, `backupDate`))",
         "fields": [
+          {
+            "fieldPath": "backupVersionCode",
+            "columnName": "backupVersionCode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
           {
             "fieldPath": "packageName",
             "columnName": "packageName",
@@ -433,6 +439,12 @@
             "notNull": true
           },
           {
+            "fieldPath": "compressionType",
+            "columnName": "compressionType",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
             "fieldPath": "cipherType",
             "columnName": "cipherType",
             "affinity": "TEXT",
@@ -471,7 +483,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6eadb5138fe4dfb017171b5484f35cb6')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '41972af530623d54e335f87f2787aa67')"
     ]
   }
 }

--- a/app/src/androidTest/kotlin/tests/Test_BackupRestore.kt
+++ b/app/src/androidTest/kotlin/tests/Test_BackupRestore.kt
@@ -1,5 +1,6 @@
 package tests
 
+import android.util.Log
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import com.machiav3lli.backup.PREFS_ENCRYPTION
@@ -13,10 +14,17 @@ import com.machiav3lli.backup.items.RootFile
 import com.machiav3lli.backup.items.StorageFile
 import com.machiav3lli.backup.utils.getPrivateSharedPrefs
 import com.topjohnwu.superuser.ShellUtils.fastCmd
-import org.junit.*
+import org.junit.After
+import org.junit.AfterClass
 import org.junit.Assert.assertEquals
-import timber.log.Timber
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Rule
+import org.junit.Test
 import java.io.File
+import java.text.SimpleDateFormat
+import java.util.*
 
 class Test_BackupRestore {
 
@@ -30,6 +38,7 @@ class Test_BackupRestore {
 
         var backupCreated = false
         var contentLs = listOf<String>()
+        var contentCount = 0
 
         @BeforeClass @JvmStatic
         fun setupClass() {
@@ -39,8 +48,6 @@ class Test_BackupRestore {
             tempDir.deleteRecursive()
             tempDir.mkdirs()
             testDir = prepareDirectory()
-
-            Timber.plant(Timber.DebugTree())
         }
 
         @AfterClass @JvmStatic
@@ -51,7 +58,7 @@ class Test_BackupRestore {
         fun listContent(dir: RootFile): List<String> {
             //return runAsRoot("ls -bAlZ ${dir.quoted} | grep -v total | sort").out.joinToString("\n")
             return runAsRoot(
-                        "cd ${dir.quoted} ; stat -c '%y %A %f %F %U %G %s %n' *"
+                        "cd ${dir.quoted} ; stat -c '%y %A %f %F %U %G %s %n' .* * | grep -v '\\.$'"
             ).out
                 .filterNotNull()
                 .map { it.replace(Regex(""":\d\d\.\d{9}\b"""), "") }
@@ -59,32 +66,90 @@ class Test_BackupRestore {
                 .sorted()
         }
 
+        var checks = mutableMapOf<String, (file: RootFile) -> Boolean>()
+
         private fun prepareDirectory(): RootFile {
+
+            contentCount = 0
 
             tempDir.setWritable(true, false)
 
-            val dir = RootFile(tempDir, "test_data")
-            dir.mkdirs()
+            var dir: RootFile
+            var files: RootFile
 
-            val files = RootFile(dir, "files")
-            files.mkdirs()
+            run {
+                val name = "test_data"
+                dir = RootFile(tempDir, name)
+                dir.mkdirs()
+            }
 
-            val regular = RootFile(dir, "regular")
-            fastCmd("$utilBoxQ echo TEST >${regular.quoted}")
-            fastCmd("$utilBoxQ touch -d 2013-12-21T12:34:56 ${regular.quoted}")
+            run {
+                val name = "files"
+                files = RootFile(dir, name)
+                files.mkdirs()
+                checks["$name/type"] = { it.isDirectory }
+                contentCount++
+            }
 
-            val system = RootFile(dir, "regular_system")
-            fastCmd("$utilBoxQ echo SYSTEM >${regular.quoted}")
-            fastCmd("$utilBoxQ chown system:system ${regular.quoted}")
+            run {
+                val name = "regular"
+                val regularContent = "TEST"
+                val regularTime = "2013-12-21T12:34:56"
+                val regular = RootFile(dir, name)
+                fastCmd("$utilBoxQ echo -n '$regularContent' >${regular.quoted}")
+                fastCmd("$utilBoxQ touch -d $regularTime ${regular.quoted}")
+                checks["$name/type"] = { it.isFile }
+                checks["$name/content"] = { it.readText() == regularContent }
+                checks["#$name/time"] = {
+                    SimpleDateFormat(
+                        "yyyy-MM-dd'T'HH:mm:ss",
+                        Locale.getDefault()
+                    ).format(it.lastModified()) == regularTime
+                }
+                contentCount++
+            }
 
-            val fifo = RootFile(dir, "fifo")
-            fastCmd("$utilBoxQ mkfifo ${fifo.quoted}")
+            run {
+                val name = "regular_system"
+                val systemContent = "SYSTEM"
+                val system = RootFile(dir, name)
+                fastCmd("$utilBoxQ echo -n '$systemContent' >${system.quoted}")
+                fastCmd("$utilBoxQ chown system:system ${system.quoted}")
+                checks["$name/type"] = { it.isFile }
+                checks["$name/content"] = { it.readText() == systemContent }
+                contentCount++
+            }
 
-            val symLinkDirRel = RootFile(dir, "link_sym_dir_rel")
-            fastCmd("cd ${dir.quoted} && $utilBoxQ ln -s ${files.name} ${symLinkDirRel.name}")
+            run {
+                val name = "fifo"
+                val fifo = RootFile(dir, name)
+                fastCmd("$utilBoxQ mkfifo ${fifo.quoted}")
+                contentCount++
+            }
 
-            val symLinkDirAbs = RootFile(dir, "link_sym_dir_abs")
-            fastCmd("$utilBoxQ ln -s ${files.absolutePath} ${symLinkDirAbs.quoted}")
+            run {
+                val name = "link_sym_dir_rel"
+                val symLinkDirRel = RootFile(dir, name)
+                fastCmd("cd ${dir.quoted} && $utilBoxQ ln -s ${files.name} ${symLinkDirRel.name}")
+                checks["$name/type"] = { it.isSymlink() }
+                contentCount++
+            }
+
+            run {
+                val name = "link_sym_dir_abs"
+                val symLinkDirAbs = RootFile(dir, name)
+                fastCmd("$utilBoxQ ln -s ${files.absolutePath} ${symLinkDirAbs.quoted}")
+                checks["$name/type"] = { it.isSymlink() }
+                contentCount++
+            }
+
+            run {
+                val name = "..dir"
+                val dotdotdir = RootFile(dir, name)
+                fastCmd("$utilBoxQ mkdir -p ${dotdotdir.quoted}")
+                checks["$name/type"] = { it.isDirectory }
+                contentCount++
+            }
 
             contentLs = listContent(dir)
 
@@ -124,13 +189,23 @@ class Test_BackupRestore {
     fun checkDirectory(dir: RootFile) {
         val want = contentLs
         val real = listContent(dir)
-        assert(want.isNotEmpty())
-        assert(real.isNotEmpty())
+        assertTrue(want.isNotEmpty())
+        assertTrue(real.isNotEmpty())
+        checks.forEach { (name, check) ->
+            if(name.startsWith("#"))
+                return
+            val fileName = name.split("/")[0]
+            val result = check(RootFile(dir, fileName))
+            if(!result)
+                Log.w("checkDirectory", name)
+            assertTrue("check failed for $name", result)
+        }
         assertEquals(want, real)
     }
 
     @Test
-    fun test_directoryContents() {
+    fun test_sourceContents() {
+        assertTrue(contentLs.size == contentCount)
         checkDirectory(testDir)
     }
 

--- a/app/src/main/java/com/machiav3lli/backup/actions/BackupAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/BackupAppAction.kt
@@ -210,14 +210,17 @@ open class BackupAppAction(context: Context, work: AppActionWork?, shell: ShellH
         compress: Boolean,
         iv: ByteArray?
     ) {
+        val password = context.getEncryptionPassword()
+        val compressionLevel = context.getCompressionLevel()
+        val compress = compress && (compressionLevel > 0)
+
         Timber.i("Creating $what backup via API")
         val backupFilename =
             getBackupArchiveFilename(what, compress, iv != null && context.isEncryptionEnabled())
         val backupFile = backupInstanceDir.createFile("application/octet-stream", backupFilename)
 
-        val password = context.getEncryptionPassword()
         val gzipParams = GzipParameters()
-        gzipParams.compressionLevel = context.getCompressionLevel()
+        gzipParams.compressionLevel = compressionLevel
 
         var outStream: OutputStream = backupFile.outputStream()!!
 
@@ -396,6 +399,11 @@ open class BackupAppAction(context: Context, work: AppActionWork?, shell: ShellH
         if (!ShellUtils.fastCmdResult("test -d ${quote(sourcePath)}"))
             return false
         Timber.i("Creating $dataType backup via tar")
+
+        val password = context.getEncryptionPassword()
+        val compressionLevel = context.getCompressionLevel()
+        val compress = compress && (compressionLevel > 0)
+
         val backupFilename = getBackupArchiveFilename(
             dataType,
             compress,
@@ -403,9 +411,8 @@ open class BackupAppAction(context: Context, work: AppActionWork?, shell: ShellH
         )
         val backupFile = backupInstanceDir.createFile("application/octet-stream", backupFilename)
 
-        val password = context.getEncryptionPassword()
         val gzipParams = GzipParameters()
-        gzipParams.compressionLevel = context.getCompressionLevel()
+        gzipParams.compressionLevel = compressionLevel
 
         var outStream: OutputStream = backupFile.outputStream()!!
 

--- a/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
@@ -281,8 +281,11 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
             }
             val sb = StringBuilder()
             val disableVerification = context.isDisableVerification
+
             // disable verify apps over usb
-            if (disableVerification) sb.append("settings put global verifier_verify_adb_installs 0 ; ")
+            if (disableVerification)
+                runAsRoot("settings put global verifier_verify_adb_installs 0")
+
             // Install main package
             sb.append(
                 getPackageInstallCommand(
@@ -303,11 +306,14 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
                 }
             }
 
-            // re-enable verify apps over usb
-            if (disableVerification) sb.append(" ; settings put global verifier_verify_adb_installs 1")
             val command = sb.toString()
             runAsRoot(command)
             success = true
+
+            // re-enable verify apps over usb
+            if (disableVerification)
+                runAsRoot("settings put global verifier_verify_adb_installs 1")
+
             // Todo: Reload package meta data; Package Manager knows everything now; Function missing
         } catch (e: ShellCommandFailedException) {
             val error = extractErrorMessage(e.shellResult)

--- a/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
@@ -61,7 +61,6 @@ import com.machiav3lli.backup.utils.suRecursiveCopyFileFromDocument
 import com.machiav3lli.backup.utils.suUnpackTo
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
-import org.apache.commons.io.FileUtils
 import timber.log.Timber
 import java.io.BufferedInputStream
 import java.io.File
@@ -456,7 +455,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
             // Clean up the temporary directory if it was initialized
             tempDir?.let {
                 try {
-                    FileUtils.forceDelete(it)
+                    it.deleteRecursive()
                 } catch (e: IOException) {
                     Timber.e("Could not delete temporary directory $it. Cache Size might be growing. Reason: $e")
                 }

--- a/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
@@ -18,7 +18,19 @@
 package com.machiav3lli.backup.actions
 
 import android.content.Context
-import com.machiav3lli.backup.*
+import com.machiav3lli.backup.MODE_APK
+import com.machiav3lli.backup.MODE_DATA
+import com.machiav3lli.backup.MODE_DATA_DE
+import com.machiav3lli.backup.MODE_DATA_EXT
+import com.machiav3lli.backup.MODE_DATA_MEDIA
+import com.machiav3lli.backup.MODE_DATA_OBB
+import com.machiav3lli.backup.OABX
+import com.machiav3lli.backup.PREFS_EXCLUDECACHE
+import com.machiav3lli.backup.PREFS_REFRESHDELAY
+import com.machiav3lli.backup.PREFS_REFRESHTIMEOUT
+import com.machiav3lli.backup.PREFS_RESTOREAVOIDTEMPCOPY
+import com.machiav3lli.backup.PREFS_RESTORETARCMD
+import com.machiav3lli.backup.R
 import com.machiav3lli.backup.dbs.entity.Backup
 import com.machiav3lli.backup.handler.LogsHandler
 import com.machiav3lli.backup.handler.ShellHandler
@@ -34,12 +46,28 @@ import com.machiav3lli.backup.items.Package
 import com.machiav3lli.backup.items.RootFile
 import com.machiav3lli.backup.items.StorageFile
 import com.machiav3lli.backup.tasks.AppActionWork
-import com.machiav3lli.backup.utils.*
+import com.machiav3lli.backup.utils.CryptoSetupException
+import com.machiav3lli.backup.utils.decryptStream
+import com.machiav3lli.backup.utils.getCryptoSalt
+import com.machiav3lli.backup.utils.getDefaultSharedPreferences
+import com.machiav3lli.backup.utils.getEncryptionPassword
+import com.machiav3lli.backup.utils.isAllowDowngrade
+import com.machiav3lli.backup.utils.isDisableVerification
+import com.machiav3lli.backup.utils.isEncryptionEnabled
+import com.machiav3lli.backup.utils.isPauseApps
+import com.machiav3lli.backup.utils.isRestoreAllPermissions
+import com.machiav3lli.backup.utils.suCopyFileFromDocument
+import com.machiav3lli.backup.utils.suRecursiveCopyFileFromDocument
+import com.machiav3lli.backup.utils.suUnpackTo
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
 import org.apache.commons.io.FileUtils
 import timber.log.Timber
-import java.io.*
+import java.io.BufferedInputStream
+import java.io.File
+import java.io.FileNotFoundException
+import java.io.IOException
+import java.io.InputStream
 import java.nio.file.Files
 
 open class RestoreAppAction(context: Context, work: AppActionWork?, shell: ShellHandler) :
@@ -346,7 +374,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
     @Throws(CryptoSetupException::class, IOException::class)
     protected fun openArchiveFile(
         archive: StorageFile,
-        compressed: Boolean,
+        isCompressed: Boolean,
         isEncrypted: Boolean,
         iv: ByteArray?
     ): InputStream {
@@ -358,7 +386,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
                 inputStream = inputStream.decryptStream(password, context.getCryptoSalt(), iv)
             }
         }
-        if (compressed) {
+        if (isCompressed) {
             inputStream = GzipCompressorInputStream(inputStream)
         }
         return inputStream
@@ -369,7 +397,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
         dataType: String,
         archive: StorageFile,
         targetPath: String,
-        compressed: Boolean,
+        isCompressed: Boolean,
         isEncrypted: Boolean,
         iv: ByteArray?,
         cachePath: File?
@@ -381,7 +409,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
         var tempDir: RootFile? = null
         try {
             TarArchiveInputStream(
-                openArchiveFile(archive, compressed, isEncrypted, iv)
+                openArchiveFile(archive, isCompressed, isEncrypted, iv)
             ).use { archiveStream ->
                 if (OABX.prefFlag(PREFS_RESTOREAVOIDTEMPCOPY, true)) {
                     // clear the data from the final directory
@@ -441,7 +469,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
         dataType: String,
         archive: StorageFile,
         targetPath: String,
-        compressed: Boolean,
+        isCompressed: Boolean,
         isEncrypted: Boolean,
         iv: ByteArray?
     ) {
@@ -451,7 +479,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
                 throw RestoreFailedException("Backup archive at $archive is missing")
             }
             try {
-                openArchiveFile(archive, compressed, isEncrypted, iv).use { archiveStream ->
+                openArchiveFile(archive, isCompressed, isEncrypted, iv).use { archiveStream ->
 
                     targetDir.mkdirs()  // in case it doesn't exist
 
@@ -533,7 +561,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
         dataType: String,
         archive: StorageFile,
         targetPath: String,
-        compressed: Boolean,
+        isCompressed: Boolean,
         isEncrypted: Boolean,
         iv: ByteArray?,
         cachePath: File?
@@ -544,7 +572,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
                 dataType,
                 archive,
                 targetPath,
-                compressed,
+                isCompressed,
                 isEncrypted,
                 iv
             )
@@ -553,7 +581,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
                 dataType,
                 archive,
                 targetPath,
-                compressed,
+                isCompressed,
                 isEncrypted,
                 iv,
                 cachePath
@@ -617,7 +645,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
         val dataType = BACKUP_DIR_DATA
         val backupFilename = getBackupArchiveFilename(
             dataType,
-            compressed,
+            backup.isCompressed,
             backup.isEncrypted
         )
         Timber.d(LOG_EXTRACTING_S, backup.packageName, backupFilename)
@@ -643,7 +671,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
             dataType,
             backupArchive,
             extractTo,
-            compressed,
+            backup.isCompressed,
             backup.isEncrypted,
             backup.iv,
             RootFile(context.cacheDir)
@@ -665,7 +693,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
         val dataType = BACKUP_DIR_DEVICE_PROTECTED_FILES
         val backupFilename = getBackupArchiveFilename(
             dataType,
-            compressed,
+            backup.isCompressed,
             backup.isEncrypted
         )
         Timber.d(LOG_EXTRACTING_S, backup.packageName, backupFilename)
@@ -691,7 +719,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
             dataType,
             backupArchive,
             extractTo,
-            compressed,
+            backup.isCompressed,
             backup.isEncrypted,
             backup.iv,
             RootFile(deviceProtectedStorageContext.cacheDir)
@@ -713,7 +741,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
         val dataType = BACKUP_DIR_EXTERNAL_FILES
         val backupFilename = getBackupArchiveFilename(
             dataType,
-            compressed,
+            backup.isCompressed,
             backup.isEncrypted
         )
         Timber.d(LOG_EXTRACTING_S, backup.packageName, backupFilename)
@@ -734,7 +762,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
             dataType,
             backupArchive,
             extractTo,
-            compressed,
+            backup.isCompressed,
             backup.isEncrypted,
             backup.iv,
             context.externalCacheDir?.let { RootFile(it) }
@@ -763,7 +791,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
         val dataType = BACKUP_DIR_OBB_FILES
         val backupFilename = getBackupArchiveFilename(
             dataType,
-            compressed,
+            backup.isCompressed,
             backup.isEncrypted
         )
         Timber.d(LOG_EXTRACTING_S, backup.packageName, backupFilename)
@@ -783,7 +811,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
             dataType,
             backupArchive,
             extractTo,
-            compressed,
+            backup.isCompressed,
             backup.isEncrypted,
             backup.iv,
             context.externalCacheDir?.let { RootFile(it) }
@@ -812,7 +840,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
         val dataType = BACKUP_DIR_MEDIA_FILES
         val backupFilename = getBackupArchiveFilename(
             dataType,
-            compressed,
+            backup.isCompressed,
             backup.isEncrypted
         )
         Timber.d(LOG_EXTRACTING_S, backup.packageName, backupFilename)
@@ -832,7 +860,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
             dataType,
             backupArchive,
             extractTo,
-            compressed,
+            backup.isCompressed,
             backup.isEncrypted,
             backup.iv,
             context.externalCacheDir?.let { RootFile(it) }

--- a/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.kt
+++ b/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.kt
@@ -31,7 +31,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.NavHostFragment
 import com.machiav3lli.backup.BuildConfig
 import com.machiav3lli.backup.OABX
-import com.machiav3lli.backup.OABX.Companion.appsSuspendedChecked
 import com.machiav3lli.backup.PREFS_CATCHUNCAUGHT
 import com.machiav3lli.backup.PREFS_SKIPPEDENCRYPTION
 import com.machiav3lli.backup.R
@@ -58,23 +57,10 @@ import com.machiav3lli.backup.utils.sortOrder
 import com.machiav3lli.backup.viewmodels.MainViewModel
 import com.topjohnwu.superuser.Shell
 import timber.log.Timber
-import java.lang.ref.WeakReference
 import kotlin.system.exitProcess
 
 
 class MainActivityX : BaseActivity() {
-
-    companion object {
-
-        var activityRef: WeakReference<MainActivityX> = WeakReference(null)
-        var activity: MainActivityX?
-            get() {
-                return activityRef.get()
-            }
-            set(activity) {
-                activityRef = WeakReference(activity)
-            }
-    }
 
     private lateinit var prefs: SharedPreferences
     private lateinit var refreshViewController: RefreshViewController
@@ -86,13 +72,12 @@ class MainActivityX : BaseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val context = this
-        activity = this
         OABX.activity = this
 
         setCustomTheme()
         super.onCreate(savedInstanceState)
 
-        appsSuspendedChecked = false
+        OABX.appsSuspendedChecked = false
 
         if (OABX.prefFlag(PREFS_CATCHUNCAUGHT, true)) {
             Thread.setDefaultUncaughtExceptionHandler { _, e ->
@@ -112,7 +97,7 @@ class MainActivityX : BaseActivity() {
                             Looper.prepare()
                             repeat(5) {
                                 Toast.makeText(
-                                    activity,
+                                    context,
                                     "Uncaught Exception\n${e.message}\nrestarting application...",
                                     Toast.LENGTH_LONG
                                 ).show()
@@ -164,6 +149,7 @@ class MainActivityX : BaseActivity() {
     }
 
     override fun onResume() {
+        OABX.activity = this    // just in case 'this' object is recreated
         super.onResume()
         if (isNeedRefresh) {
             viewModel.refreshList()
@@ -189,7 +175,7 @@ class MainActivityX : BaseActivity() {
                 // ignore?
             }
             else -> {
-                activity?.showToast("Main: unknown command '$command'")
+                showToast("Main: unknown command '$command'")
             }
         }
         return false
@@ -287,12 +273,12 @@ class MainActivityX : BaseActivity() {
     }
 
     fun whileShowingSnackBar(message: String, todo: () -> Unit) {
-        activity?.runOnUiThread {
-            activity?.showSnackBar(message)
+        runOnUiThread {
+            showSnackBar(message)
         }
         todo()
-        activity?.runOnUiThread {
-            activity?.dismissSnackBar()
+        runOnUiThread {
+            dismissSnackBar()
         }
     }
 

--- a/app/src/main/java/com/machiav3lli/backup/handler/BackupBuilder.kt
+++ b/app/src/main/java/com/machiav3lli/backup/handler/BackupBuilder.kt
@@ -37,6 +37,7 @@ class BackupBuilder(
     private var hasExternalData = false
     private var hasObbData = false
     private var hasMediaData = false
+    private var compressionType: String? = null
     private var cipherType: String? = null
     private val cpuArch: String = Build.SUPPORTED_ABIS[0]
     val backupPath = ensureBackupPath(backupRoot)
@@ -76,6 +77,10 @@ class BackupBuilder(
         this.hasMediaData = hasMediaData
     }
 
+    fun setCompressionType(compressionType: String?) {
+        this.compressionType = compressionType
+    }
+
     fun setCipherType(cipherType: String?) {
         this.cipherType = cipherType
     }
@@ -90,6 +95,7 @@ class BackupBuilder(
             hasExternalData = hasExternalData,
             hasObbData = hasObbData,
             hasMediaData = hasMediaData,
+            compressionType = compressionType,
             cipherType = cipherType,
             iv = iv,
             cpuArch = cpuArch,
@@ -100,7 +106,7 @@ class BackupBuilder(
     /*fun createBackupProperties(): BackupProperties {
         return BackupProperties(
             appInfo, backupDate, hasApk, hasAppData, hasDevicesProtectedData,
-            hasExternalData, hasObbData, hasMediaData, cipherType, iv, cpuArch
+            hasExternalData, hasObbData, hasMediaData, compressionType, cipherType, iv, cpuArch
         )
     }*/
 }

--- a/app/src/main/java/com/machiav3lli/backup/handler/LogsHandler.kt
+++ b/app/src/main/java/com/machiav3lli/backup/handler/LogsHandler.kt
@@ -103,7 +103,18 @@ class LogsHandler(var context: Context) {
         }
 
         fun stackTrace(e: Throwable) = e.stackTrace.joinToString("\nat ", "at ")
-        fun message(e: Throwable) = e.toString() + "\n" + stackTrace(e)
+        fun message(e: Throwable, backTrace: Boolean = false) =
+                "${e::class.simpleName}${
+                    if(e.cause != null)
+                        "\ncause: ${e.cause}" 
+                    else
+                        ""
+                }${
+                    if(backTrace) 
+                        "\n${stackTrace(e)}" 
+                    else 
+                        ""
+                }"
 
         fun logException(e: Throwable, what: Any? = null, prefix: String? = null) {
             var whatStr = ""
@@ -114,7 +125,7 @@ class LogsHandler(var context: Context) {
                 else
                     "$whatStr : "
             }
-            Timber.e("$prefix$e $whatStr\n${stackTrace(e)}")
+            Timber.e("$prefix$whatStr\n${message(e, true)}")
         }
 
         fun unhandledException(e: Throwable, what: Any? = null) {

--- a/app/src/main/java/com/machiav3lli/backup/handler/ShellHandler.kt
+++ b/app/src/main/java/com/machiav3lli/backup/handler/ShellHandler.kt
@@ -17,12 +17,10 @@
  */
 package com.machiav3lli.backup.handler
 
-import android.os.Environment.DIRECTORY_DOCUMENTS
-import android.telephony.mbms.FileInfo
 //import com.google.code.regexp.Pattern
+import android.os.Environment.DIRECTORY_DOCUMENTS
 import com.machiav3lli.backup.BuildConfig
 import com.machiav3lli.backup.OABX
-import com.machiav3lli.backup.activities.MainActivityX.Companion.activity
 import com.machiav3lli.backup.handler.ShellHandler.FileInfo.FileType
 import com.machiav3lli.backup.utils.BUFFER_SIZE
 import com.machiav3lli.backup.utils.FileUtils.translatePosixPermissionToMode
@@ -67,7 +65,7 @@ class ShellHandler {
         assets = AssetHandler(OABX.context)
         scriptDir = assets.directory
         scriptUserDir = File(
-            activity?.getExternalFilesDir(DIRECTORY_DOCUMENTS),
+            OABX.activity?.getExternalFilesDir(DIRECTORY_DOCUMENTS),
             SCRIPTS_SUBDIR
         )
         scriptUserDir?.mkdirs()

--- a/app/src/main/java/com/machiav3lli/backup/handler/WorkHandler.kt
+++ b/app/src/main/java/com/machiav3lli/backup/handler/WorkHandler.kt
@@ -94,7 +94,7 @@ class WorkHandler {
             val longAgo = 24 * 60 * 60 * 1000
             batchesKnown.keys.toList().forEach { // copy the keys, because collection changes now
                 batchesKnown[it]?.let { batch ->
-                    if (batch.isFinished == true) {
+                    if (batch.isFinished) {
                         val now = System.currentTimeMillis()
                         if (now - batch.startTime > longAgo) {
                             Timber.d("%%%%% $it removing...\\")
@@ -263,11 +263,11 @@ class WorkHandler {
 
         fun onProgress(handler: WorkHandler, workInfos: MutableList<WorkInfo>? = null) {
             synchronized(batchesStarted) {
-                onProgress_(handler, workInfos)
+                onProgressNoSync(handler, workInfos)
             }
         }
 
-        fun onProgress_(handler: WorkHandler, workInfos: MutableList<WorkInfo>? = null) {
+        fun onProgressNoSync(handler: WorkHandler, workInfos: MutableList<WorkInfo>? = null) {
 
             val manager = handler.manager
             val work = workInfos
@@ -298,7 +298,7 @@ class WorkHandler {
                     batchName = getTagVar(info.tags, "name")
                 }
                 if (batchName.isNullOrEmpty()) {
-                    batchName = WorkHandler.getBatchName("NoName@Work", 0)
+                    batchName = getBatchName("NoName@Work", 0)
                     Timber.d("?????????????????????????? name not set, using $batchName")
                 }
 

--- a/app/src/main/java/com/machiav3lli/backup/ui/compose/item/BackupItem.kt
+++ b/app/src/main/java/com/machiav3lli/backup/ui/compose/item/BackupItem.kt
@@ -2,9 +2,18 @@ package com.machiav3lli.backup.ui.compose.item
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.*
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -80,6 +89,17 @@ fun BackupItem(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
+                AnimatedVisibility(visible = item.isCompressed) {
+                    Text(
+                        text = item.compressionType ?: "",
+                        modifier = Modifier.align(Alignment.CenterVertically),
+                        softWrap = true,
+                        overflow = TextOverflow.Ellipsis,
+                        maxLines = 1,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
                 AnimatedVisibility(visible = item.isEncrypted) {
                     Text(
                         text = item.cipherType ?: "",

--- a/app/src/main/java/com/machiav3lli/backup/utils/PrefUtils.kt
+++ b/app/src/main/java/com/machiav3lli/backup/utils/PrefUtils.kt
@@ -21,7 +21,11 @@ import android.Manifest
 import android.app.Activity
 import android.app.AppOpsManager
 import android.app.KeyguardManager
-import android.content.*
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.DialogInterface
+import android.content.Intent
+import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
@@ -36,7 +40,35 @@ import androidx.core.app.ActivityCompat
 import androidx.preference.PreferenceManager
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
-import com.machiav3lli.backup.*
+import com.machiav3lli.backup.NEED_REFRESH
+import com.machiav3lli.backup.PREFS_ACCENT_COLOR
+import com.machiav3lli.backup.PREFS_ALLOWDOWNGRADE
+import com.machiav3lli.backup.PREFS_BIOMETRICLOCK
+import com.machiav3lli.backup.PREFS_COMPRESSION_LEVEL
+import com.machiav3lli.backup.PREFS_DEVICELOCK
+import com.machiav3lli.backup.PREFS_DEVICEPROTECTEDDATA
+import com.machiav3lli.backup.PREFS_DISABLEVERIFICATION
+import com.machiav3lli.backup.PREFS_ENABLESPECIALBACKUPS
+import com.machiav3lli.backup.PREFS_ENCRYPTION
+import com.machiav3lli.backup.PREFS_EXTERNALDATA
+import com.machiav3lli.backup.PREFS_IGNORE_BATTERY_OPTIMIZATION
+import com.machiav3lli.backup.PREFS_LANGUAGES
+import com.machiav3lli.backup.PREFS_LANGUAGES_DEFAULT
+import com.machiav3lli.backup.PREFS_MEDIADATA
+import com.machiav3lli.backup.PREFS_OBBDATA
+import com.machiav3lli.backup.PREFS_PASSWORD
+import com.machiav3lli.backup.PREFS_PASSWORD_CONFIRMATION
+import com.machiav3lli.backup.PREFS_PATH_BACKUP_DIRECTORY
+import com.machiav3lli.backup.PREFS_PAUSEAPPS
+import com.machiav3lli.backup.PREFS_REMEMBERFILTERING
+import com.machiav3lli.backup.PREFS_RESTOREWITHALLPERMISSIONS
+import com.machiav3lli.backup.PREFS_SALT
+import com.machiav3lli.backup.PREFS_SECONDARY_COLOR
+import com.machiav3lli.backup.PREFS_SHARED_PRIVATE
+import com.machiav3lli.backup.PREFS_SORT_FILTER
+import com.machiav3lli.backup.PREFS_SORT_ORDER
+import com.machiav3lli.backup.PREFS_THEME
+import com.machiav3lli.backup.R
 import com.machiav3lli.backup.handler.ShellHandler
 import com.machiav3lli.backup.items.SortFilterModel
 import com.machiav3lli.backup.items.StorageFile
@@ -90,6 +122,10 @@ fun Context.getEncryptionPasswordConfirmation(): String =
 
 fun Context.setEncryptionPasswordConfirmation(value: String) =
     getPrivateSharedPrefs().edit().putString(PREFS_PASSWORD_CONFIRMATION, value).commit()
+
+fun Context.isCompressionEnabled(): Boolean =
+    getCompressionLevel() > 0
+        // && compression algorithm != null
 
 fun Context.getCompressionLevel() =
     getDefaultSharedPreferences().getInt(PREFS_COMPRESSION_LEVEL, 5)

--- a/app/src/main/java/com/machiav3lli/backup/utils/PrefUtils.kt
+++ b/app/src/main/java/com/machiav3lli/backup/utils/PrefUtils.kt
@@ -106,8 +106,7 @@ fun Context.getCryptoSalt(): ByteArray {
 
 fun Context.isEncryptionEnabled(): Boolean =
     getDefaultSharedPreferences().getBoolean(PREFS_ENCRYPTION, false)
-            && getPrivateSharedPrefs().getString(PREFS_PASSWORD, "")?.isNotEmpty()
-            ?: false
+            && getEncryptionPassword().isNotEmpty()
 
 fun Context.getEncryptionPassword(): String =
     getPrivateSharedPrefs().getString(PREFS_PASSWORD, "")

--- a/app/src/main/res/xml/preferences_service.xml
+++ b/app/src/main/res/xml/preferences_service.xml
@@ -102,6 +102,6 @@
         android:max="9"
         android:summary="@string/prefs_compression_level_summary"
         android:title="@string/prefs_compression_level"
-        app:min="1"
+        app:min="0"
         app:showSeekBarValue="true" />
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Antonios, please choose a level you want to accept (rejected commits will the return later in another PR, after discussion):

* compression=0 -> uncompressed backup
* load compression type from properties, so backups can have mixed flags
* add backupVersionCode for later use (e.g. allow v8 to load v7 backups)
* because toybox has bugs, users can copy a fixed toybox to /data/local (we might provide a flashable zip if a fixed version exists, or take the working A10 toybox instead -> needs to be tested)
* fix: in case disableVerfication is enabled, Neo Backup ignored the return code of pm install (might be replaced by a script, some time in the future)
* add a system to check additional conditions to backup test