### PR TITLE
oldVersion compatibility, several fixes

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/actions/RestoreSpecialAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/RestoreSpecialAction.kt
@@ -74,7 +74,7 @@ class RestoreSpecialAction(context: Context, work: AppActionWork?, shell: ShellH
             ).use { archiveStream ->
                 tempPath.mkdir()
                 // Extract the contents to a temporary directory
-                archiveStream.suUnpackTo(tempPath)
+                archiveStream.suUnpackTo(tempPath, isOldVersion(backup))
 
                 // check if all expected files are there
                 val filesInBackup = tempPath.listFiles()

--- a/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.kt
+++ b/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.kt
@@ -32,6 +32,7 @@ import androidx.navigation.fragment.NavHostFragment
 import com.machiav3lli.backup.BuildConfig
 import com.machiav3lli.backup.OABX
 import com.machiav3lli.backup.PREFS_CATCHUNCAUGHT
+import com.machiav3lli.backup.PREFS_MAXCRASHLINES
 import com.machiav3lli.backup.PREFS_SKIPPEDENCRYPTION
 import com.machiav3lli.backup.R
 import com.machiav3lli.backup.databinding.ActivityMainXBinding

--- a/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.kt
+++ b/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.kt
@@ -29,7 +29,11 @@ import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.NavHostFragment
-import com.machiav3lli.backup.*
+import com.machiav3lli.backup.BuildConfig
+import com.machiav3lli.backup.OABX
+import com.machiav3lli.backup.PREFS_CATCHUNCAUGHT
+import com.machiav3lli.backup.PREFS_SKIPPEDENCRYPTION
+import com.machiav3lli.backup.R
 import com.machiav3lli.backup.databinding.ActivityMainXBinding
 import com.machiav3lli.backup.dbs.ODatabase
 import com.machiav3lli.backup.dbs.entity.AppExtras
@@ -39,7 +43,17 @@ import com.machiav3lli.backup.handler.LogsHandler
 import com.machiav3lli.backup.handler.ShellHandler.Companion.runAsRoot
 import com.machiav3lli.backup.items.SortFilterModel
 import com.machiav3lli.backup.items.StorageFile
-import com.machiav3lli.backup.utils.*
+import com.machiav3lli.backup.utils.getPrivateSharedPrefs
+import com.machiav3lli.backup.utils.isEncryptionEnabled
+import com.machiav3lli.backup.utils.isNeedRefresh
+import com.machiav3lli.backup.utils.isRememberFiltering
+import com.machiav3lli.backup.utils.itemIdToOrder
+import com.machiav3lli.backup.utils.navigateLeft
+import com.machiav3lli.backup.utils.navigateRight
+import com.machiav3lli.backup.utils.setCustomTheme
+import com.machiav3lli.backup.utils.showToast
+import com.machiav3lli.backup.utils.sortFilterModel
+import com.machiav3lli.backup.utils.sortOrder
 import com.machiav3lli.backup.viewmodels.MainViewModel
 import com.topjohnwu.superuser.Shell
 import timber.log.Timber
@@ -84,7 +98,7 @@ class MainActivityX : BaseActivity() {
                             repeat(5) {
                                 Toast.makeText(
                                     context,
-                                    "Uncaught Exception\n${e.message}\nrestarting application...",
+                                    "Uncaught Exception\n${e.message}\n${e.cause}\nrestarting application...",
                                     Toast.LENGTH_LONG
                                 ).show()
                             }

--- a/app/src/main/java/com/machiav3lli/backup/dbs/entity/Backup.kt
+++ b/app/src/main/java/com/machiav3lli/backup/dbs/entity/Backup.kt
@@ -40,7 +40,7 @@ import java.time.LocalDateTime
 @Entity(primaryKeys = ["packageName", "backupDate"])
 @Serializable
 data class Backup constructor(
-    var backupVersionCode: Int,
+    var backupVersionCode: Int = 0,
     var packageName: String,
     var packageLabel: String?,
     var versionName: String?,
@@ -58,7 +58,7 @@ data class Backup constructor(
     var hasObbData: Boolean,
     var hasMediaData: Boolean,
     var compressionType: String? = "gz",
-    var cipherType: String?,
+    var cipherType: String? = null,
     var iv: ByteArray?,
     var cpuArch: String?,
     var permissions: List<String> = listOf()

--- a/app/src/main/java/com/machiav3lli/backup/dbs/entity/Backup.kt
+++ b/app/src/main/java/com/machiav3lli/backup/dbs/entity/Backup.kt
@@ -32,6 +32,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import timber.log.Timber
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
@@ -46,7 +47,7 @@ data class Backup constructor(
     var versionName: String?,
     var versionCode: Int,
     var profileId: Int,
-    var sourceDir: String?,
+    var sourceDir: String? = null,
     var splitSourceDirs: Array<String> = arrayOf(),
     var isSystem: Boolean,
     @Serializable(with = LocalDateTimeSerializer::class)
@@ -254,7 +255,10 @@ data class Backup constructor(
     ) : Exception(message, cause)
 
     companion object {
-        fun fromJson(json: String) = Json.decodeFromString<Backup>(json)
+        fun fromJson(json: String): Backup? {
+            Timber.d("json: $json")
+            return Json.decodeFromString<Backup>(json)
+        }
 
         fun createFrom(propertiesFile: StorageFile): Backup? = try {
             fromJson(propertiesFile.inputStream()!!.reader().readText())

--- a/app/src/main/java/com/machiav3lli/backup/fragments/LogsFragment.kt
+++ b/app/src/main/java/com/machiav3lli/backup/fragments/LogsFragment.kt
@@ -21,10 +21,17 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
 import androidx.compose.material.Scaffold
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
+import com.machiav3lli.backup.R
 import com.machiav3lli.backup.databinding.FragmentRecyclerBinding
 import com.machiav3lli.backup.ui.compose.recycler.LogRecycler
 import com.machiav3lli.backup.ui.compose.theme.AppTheme
@@ -41,6 +48,26 @@ class LogsFragment : Fragment() {
     ): View {
         super.onCreate(savedInstanceState)
         binding = FragmentRecyclerBinding.inflate(inflater, container, false)
+
+        //TODO apparently the actions below take a lot of time before setContent is even called
+        //TODO preset it here with a "loading..." message or may be a spinner or animation,
+        //TODO because a lot of things can happen before the content exists
+        //TODO do it like this for other recyclers, too, e.g. search, schedules, ...
+        //TODO they all do something to retrieve data and setting up databases, LiveData etc. needs trime
+        //TODO loading_list content should probably be a compose function for consistency
+        //TODO note: loading_list string changed to not include "application"
+        binding.recyclerView.setContent {
+            Box(
+                modifier = Modifier
+                    .background(MaterialTheme.colorScheme.background),
+                contentAlignment = Alignment.Center
+            ) {
+                androidx.compose.material3.Text(
+                    text = stringResource(id = R.string.loading_list),
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+            }
+        }
 
         val viewModelFactory = LogViewModel.Factory(requireActivity().application)
         viewModel = ViewModelProvider(this, viewModelFactory)[LogViewModel::class.java]

--- a/app/src/main/java/com/machiav3lli/backup/handler/LogsHandler.kt
+++ b/app/src/main/java/com/machiav3lli/backup/handler/LogsHandler.kt
@@ -111,7 +111,7 @@ class LogsHandler(var context: Context) {
                         ""
                 }${
                     if(e.cause != null)
-                        "\ncause: ${e.cause}" 
+                        "\ncause: ${e.cause}"
                     else
                         ""
                 }${
@@ -121,7 +121,12 @@ class LogsHandler(var context: Context) {
                         ""
                 }"
 
-        fun logException(e: Throwable, what: Any? = null, prefix: String? = null) {
+        fun logException(
+            e: Throwable,
+            what: Any? = null,
+            backTrace: Boolean = false,
+            prefix: String? = null
+        ) {
             var whatStr = ""
             if (what != null) {
                 whatStr = what.toString()
@@ -130,11 +135,11 @@ class LogsHandler(var context: Context) {
                 else
                     "$whatStr : "
             }
-            Timber.e("$prefix$whatStr\n${message(e, true)}")
+            Timber.e("$prefix$whatStr\n${message(e, backTrace)}")
         }
 
         fun unhandledException(e: Throwable, what: Any? = null) {
-            logException(e, what, "unexpected: ")
+            logException(e, what, backTrace = true, "unexpected: ")
         }
 
         fun handleErrorMessages(context: Context, errorText: String?): String? {

--- a/app/src/main/java/com/machiav3lli/backup/items/Package.kt
+++ b/app/src/main/java/com/machiav3lli/backup/items/Package.kt
@@ -105,7 +105,7 @@ class Package {
                     .packageInfo
             } catch (e: Throwable) {
                 Timber.i("$packageName is not installed")
-                if (this.backupHistory.isNullOrEmpty()) {
+                if (this.backupHistory.isEmpty()) {
                     throw AssertionError(
                         "Backup History is empty and package is not installed. The package is completely unknown?",
                         e

--- a/app/src/main/java/com/machiav3lli/backup/items/StorageFile.kt
+++ b/app/src/main/java/com/machiav3lli/backup/items/StorageFile.kt
@@ -21,18 +21,9 @@ import java.io.File
 import java.io.FileNotFoundException
 import java.io.InputStream
 import java.io.OutputStream
-import kotlin.collections.ArrayList
-import kotlin.collections.List
-import kotlin.collections.MutableMap
 import kotlin.collections.component1
 import kotlin.collections.component2
-import kotlin.collections.forEach
-import kotlin.collections.joinToString
-import kotlin.collections.listOf
-import kotlin.collections.map
-import kotlin.collections.mutableMapOf
 import kotlin.collections.set
-import kotlin.collections.toList
 
 // TODO MAYBE migrate at some point to FuckSAF
 
@@ -90,13 +81,13 @@ open class StorageFile {
                                 // e.g. /storage/emulated/$user
                                 val possiblePaths = listOf(
                                     "/mnt/pass_through/$user/$storage/$subpath",
-                                    "/mnt/media_rw/$storage/$subpath",
                                     "/mnt/runtime/full/$storage/$subpath",
                                     "/mnt/runtime/default/$storage/$subpath",
 
                                     // lockups! primary links to /storage/emulated/$user and all self etc.
                                     //"/storage/$storage/$subpath",
                                     //"/storage/self/$storage/$subpath",
+                                    //"/mnt/media_rw/$storage/$subpath",
                                     //"/mnt/runtime/default/self/$storage/$subpath"
                                     //"/mnt/user/$user/$storage/$subpath",
                                     //"/mnt/user/$user/self/$storage/$subpath",

--- a/app/src/main/java/com/machiav3lli/backup/ui/compose/item/BackupItem.kt
+++ b/app/src/main/java/com/machiav3lli/backup/ui/compose/item/BackupItem.kt
@@ -2,9 +2,18 @@ package com.machiav3lli.backup.ui.compose.item
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.*
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -80,9 +89,18 @@ fun BackupItem(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                AnimatedVisibility(visible = item.isEncrypted) {
+                Text(
+                    text = if(item.backupVersionCode == 0) "old" else "${item.backupVersionCode/1000}.${item.backupVersionCode%1000}",
+                    modifier = Modifier.align(Alignment.CenterVertically),
+                    softWrap = true,
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = 1,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                AnimatedVisibility(visible = item.isCompressed) {
                     Text(
-                        text = item.cipherType ?: "",
+                        text = " - ${item.compressionType}",
                         modifier = Modifier.align(Alignment.CenterVertically),
                         softWrap = true,
                         overflow = TextOverflow.Ellipsis,
@@ -91,9 +109,9 @@ fun BackupItem(
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
-                AnimatedVisibility(visible = item.isCompressed) {
+                AnimatedVisibility(visible = item.isEncrypted) {
                     Text(
-                        text = " - ${item.compressionType}",
+                        text = " - ${item.cipherType}",
                         modifier = Modifier.align(Alignment.CenterVertically),
                         softWrap = true,
                         overflow = TextOverflow.Ellipsis,

--- a/app/src/main/java/com/machiav3lli/backup/ui/compose/item/BatchPackageItem.kt
+++ b/app/src/main/java/com/machiav3lli/backup/ui/compose/item/BatchPackageItem.kt
@@ -2,10 +2,25 @@ package com.machiav3lli.backup.ui.compose.item
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
@@ -117,9 +132,9 @@ fun BatchPackageItem(
                     )
                     AnimatedVisibility(visible = item.hasBackups) {
                         Text(
-                            text = item.latestBackup?.backupDate?.getFormattedDate(
+                            text = (item.latestBackup?.backupDate?.getFormattedDate(
                                 false
-                            ) ?: "",
+                            ) ?: "") + " - ${item.backupHistory.size}",
                             modifier = Modifier.align(Alignment.CenterVertically),
                             overflow = TextOverflow.Ellipsis,
                             maxLines = 1,

--- a/app/src/main/java/com/machiav3lli/backup/ui/compose/item/MainPackageItem.kt
+++ b/app/src/main/java/com/machiav3lli/backup/ui/compose/item/MainPackageItem.kt
@@ -2,9 +2,19 @@ package com.machiav3lli.backup.ui.compose.item
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.*
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -86,9 +96,9 @@ fun MainPackageItem(
                     )
                     AnimatedVisibility(visible = item.hasBackups) {
                         Text(
-                            text = item.latestBackup?.backupDate?.getFormattedDate(
+                            text = (item.latestBackup?.backupDate?.getFormattedDate(
                                 false
-                            ) ?: "",
+                                    ) ?: "") + " - ${item.backupHistory.size}",
                             modifier = Modifier.align(Alignment.CenterVertically),
                             overflow = TextOverflow.Ellipsis,
                             maxLines = 1,

--- a/app/src/main/java/com/machiav3lli/backup/utils/TarUtils.kt
+++ b/app/src/main/java/com/machiav3lli/backup/utils/TarUtils.kt
@@ -184,9 +184,9 @@ fun setAttributes(targetFile: RootFile, tarEntry: TarArchiveEntry) {
 }
 
 @Throws(IOException::class)
-fun TarArchiveInputStream.suUnpackTo(targetDir: RootFile) {
+fun TarArchiveInputStream.suUnpackTo(targetDir: RootFile, forceOldVersion: Boolean = false) {
     val qUtilBox = ShellHandler.utilBoxQ
-    val strictHardLinks = OABX.prefFlag(PREFS_STRICTHARDLINKS, false)
+    val strictHardLinks = OABX.prefFlag(PREFS_STRICTHARDLINKS, false) && ! forceOldVersion
     val postponeInfo = mutableMapOf<String, TarArchiveEntry>()
     generateSequence { nextTarEntry }.forEach { tarEntry ->
         val targetFile = RootFile(targetDir, tarEntry.name)

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -325,7 +325,7 @@
     <string name="batch">Stapelverarbeitung</string>
     <string name="spec_calllogsjson">Anruf-Protokolldatei JSON</string>
     <string name="intro_permission_smsmms">Die App benötigt diese Berechtigung, um SMS/MMS zu sichern und wiederherstellen zu können.</string>
-    <string name="loading_list">Die App-Liste wird geladen …</string>
+    <string name="loading_list">Die Liste wird geladen …</string>
     <string name="spec_smsmmsjson">SMS/MMS JSON</string>
     <string name="spec_fingerprint">Fingerprints</string>
     <string name="smsmms_permission_title">SMS/MMS Berechtigungen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -328,5 +328,5 @@
     <string name="spec_smsmmsjson">SMS/MMS JSON</string>
     <string name="spec_fingerprint">Huellas dactilares</string>
     <string name="calllogs_permission_title">Permisos de registros de llamadas</string>
-    <string name="loading_list">Cargando lista de aplicaciones…</string>
+    <string name="loading_list">Cargando lista…</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -125,7 +125,7 @@
     <string name="sched_excludeSystemCheckBox">Exclude aplicațiile de sistem</string>
     <string name="sortLabel">Etichetă</string>
     <string name="stats_apps">Aplicații</string>
-    <string name="loading_list">Se încarcă lista de aplicații…</string>
+    <string name="loading_list">Se încarcă lista…</string>
     <string name="prefs_encryption_summary">Activează pentru a cripta backupurile datelor</string>
     <string name="permission_not_granted">Este necesară permisiunea de a accesa spațiul de stocare extern</string>
     <string name="empty_filtered_list">Lista filtrată este goală.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -334,6 +334,6 @@
     <string name="spec_calllogsjson">JSON истории звонков</string>
     <string name="schedule">Расписание</string>
     <string name="spec_fingerprint">Отпечатки пальцев</string>
-    <string name="loading_list">Загрузка списка приложений…</string>
+    <string name="loading_list">Загрузка списка…</string>
     <string name="delete">Удалить</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -328,6 +328,6 @@
     <string name="contacts_permission_title">Дозволи контактів</string>
     <string name="intro_permission_calllogs">Застосунку потрібен цей дозвіл, щоб створювати й відновлювати резервні копії журналів ваших викликів.</string>
     <string name="batch">Декілька</string>
-    <string name="loading_list">Завантаження списку застосунків…</string>
+    <string name="loading_list">Завантаження списку…</string>
     <string name="delete">Видалити</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -330,6 +330,6 @@
     <string name="schedule">Schedule</string>
     <string name="finished">finished</string>
     <string name="batch">Batch</string>
-    <string name="loading_list">Loading apps\' list…</string>
+    <string name="loading_list">Loading list…</string>
     <string name="delete">Delete</string>
 </resources>


### PR DESCRIPTION
* adds compatibility to v7 backups (unfortunately I couldn't test much of them)
* please consider changing the version to 8.1 for upcoming releases, in case we also want to be compatible to v8 backups before alpha9, becasue those don't have the additional properties (however oldVersion also means tarapi, but this shouldn't be a problem, because it's compatible, and also fast enough for restore)
* several fixes
* added "gz" and "old" to BackupItem
* added number of  backups to list items