### PR TITLE
fix 10min limit, add packageName when calling HomePackageRecycler

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,78 @@
+# Reliability of schedules and WorkManager items
+
+this is really a multipart problem. I'll try to list all the parts:
+
+* alarm management can be
+  * inexact -> alarmManager.setAndAllowWhileIdle(...)
+  * exact -> alarmManager.setExactAndAllowWhileIdle(...)
+  * alarmclock -> alarmManager.setAlarmClock(...)
+  * reliability may mean as exact as possible or within certain contraints
+  * current tests suggest that even inexact alarms work within 5 minutes
+  * exact alarms may be equivalent to alarmclock (need to investiagte Android sources)
+* when the service receives the alarm event, it must run uninterrupted until all work items are queued
+  * the latest docs say this can/should be achieved by a wakelock
+* work items are executed at will by the Android WorkManager
+  * current docs say use setExpedited on WorkRequests (see below) 
+* each work item must run uninterrupted
+  * it is guaranteed that doWork isn't put to sleep, however we also set a wakelock   
+* a single work item may be killed if it takes too long
+  * see below
+  * if WorkManager is using JobScheduler, there is a limit of 10 minutes
+  * setExpedited should override that, but it's unclear if there are quotae
+
+
+## WorkManager
+
+https://developer.android.com/reference/androidx/work/Worker.html#doWork()
+
+"A Worker has a well defined "execution window" to finish its execution and return a ListenableWorker.Result.
+After this time has expired, the Worker will be signalled to stop."
+
+
+### "execution window" links to JobScheduler:
+
+https://developer.android.com/reference/android/app/job/JobScheduler
+
+"While a job is running, the system holds a wakelock on behalf of your app.
+For this reason, you do not need to take any action to guarantee that the device stays awake for the duration of the job."
+
+"Prior to Android version Build.VERSION_CODES.S, jobs could only have a maximum of 100 jobs scheduled at a time.
+Starting with Android version Build.VERSION_CODES.S, that limit has been increased to 150.
+Expedited jobs also count towards the limit."
+
+hg42: WorkManager probably doesn't have this limit. It can easily queue 600-800 jobs (tested many times)
+
+"In Android version Build.VERSION_CODES.LOLLIPOP, jobs had a maximum execution time of one minute.
+Starting with Android version Build.VERSION_CODES.M and ending with Android version Build.VERSION_CODES.R,
+jobs had a maximum execution time of 10 minutes.
+Starting from Android version Build.VERSION_CODES.S, jobs will still be stopped after 10 minutes
+if the system is busy or needs the resources,
+but if not, jobs may continue running longer than 10 minutes."
+
+hg42: so there is an execution limit for each job if WorkManager uses JobScheduler (Android 5.0+)
+
+also:
+
+https://stackoverflow.com/questions/53734165/android-workmanager-10-minute-thread-timeout-coming-from-somewhere
+
+> Does anyone know if a Worker, or the ThreadPoolExecutor it uses, or some other involved class has this 10 minute thread processing limit
+
+JobScheduler does, and WorkManager delegates to JobScheduler on Android 5.0+ devices.
+
+
+### WorkManager.getForegroundInfoAsync
+
+public ListenableFuture<ForegroundInfo> getForegroundInfoAsync ()
+
+Return an instance of ForegroundInfo if the WorkRequest is important to the user.
+In this case, WorkManager provides a signal to the OS that the process should be kept alive while this work is executing.
+
+Prior to Android S, WorkManager manages and runs a foreground service on your behalf to execute the WorkRequest,
+showing the notification provided in the ForegroundInfo.
+To update this notification subsequently, the application can use NotificationManager.
+
+Starting in Android S and above, WorkManager manages this WorkRequest using an immediate job.
+
+Returns  ListenableFuture<ForegroundInfo>
+A ListenableFuture of ForegroundInfo instance if the WorkRequest is marked immediate.
+For more information look at WorkRequest.Builder.setExpedited(OutOfQuotaPolicy).

--- a/app/src/main/java/com/machiav3lli/backup/actions/BackupAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/BackupAppAction.kt
@@ -82,7 +82,7 @@ open class BackupAppAction(context: Context, work: AppActionWork?, shell: ShellH
             invalidateCache { it.contains(app.packageName) }
             work?.setOperation("pre")
             val appBackupRoot: StorageFile = try {
-                app.getAppBackupRoot(context, true)!!
+                app.getAppBackupRoot(true)!!
             } catch (e: BackupLocationInAccessibleException) {
                 // Usually, this should never happen, but just in case...
                 val realException: Exception =

--- a/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.kt
+++ b/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.kt
@@ -93,20 +93,23 @@ class MainActivityX : BaseActivity() {
                                     "logcat -d -t $maxCrashLines --pid=${Process.myPid()}"  // -d = dump and exit
                                 ).out.joinToString("\n")
                     )
+                    val longToastTime = 3500
+                    val showTime = 21*1000
                     object : Thread() {
                         override fun run() {
                             Looper.prepare()
-                            repeat(5) {
+                            repeat(showTime/longToastTime) {
                                 Toast.makeText(
                                     context,
                                     "Uncaught Exception\n${e.message}\n${e.cause}\nrestarting application...",
                                     Toast.LENGTH_LONG
                                 ).show()
+                                sleep(longToastTime.toLong())
                             }
                             Looper.loop()
                         }
                     }.start()
-                    Thread.sleep(5000)
+                    Thread.sleep(showTime.toLong())
                 } catch (e: Throwable) {
                     // ignore
                 } finally {

--- a/app/src/main/java/com/machiav3lli/backup/fragments/AppSheet.kt
+++ b/app/src/main/java/com/machiav3lli/backup/fragments/AppSheet.kt
@@ -405,9 +405,7 @@ class AppSheet(val appInfo: Package, var appExtras: AppExtras) :
                 actionType === ActionType.RESTORE -> {
                     backup?.let { backupProps: Backup ->
                         val backupDir =
-                            backupProps.getBackupInstanceFolder(
-                                viewModel.appInfo.value?.getAppBackupRoot(requireContext())
-                            )
+                            backupProps.getBackupInstanceFolder(viewModel.appInfo.value?.getAppBackupRoot())
                         RestoreActionTask(
                             it, requireMainActivity(), OABX.shellHandlerInstance!!, mode,
                             backupProps, backupDir!!, this

--- a/app/src/main/java/com/machiav3lli/backup/fragments/HomeFragment.kt
+++ b/app/src/main/java/com/machiav3lli/backup/fragments/HomeFragment.kt
@@ -294,7 +294,7 @@ class HomeFragment : NavigationFragment(),
                             productsList = queriedList,
                             onClick = { item ->
                                 if (appSheet != null) appSheet?.dismissAllowingStateLoss()
-                                appSheet = AppSheet(item, AppExtras())
+                                appSheet = AppSheet(item, AppExtras(item.packageName))
                                 appSheet?.showNow(
                                     parentFragmentManager,
                                     "Package ${item.packageName}"
@@ -334,7 +334,7 @@ class HomeFragment : NavigationFragment(),
                                     UpdatedPackageRecycler(productsList = viewModel.updatedApps.value,
                                         onClick = { item ->
                                             if (appSheet != null) appSheet?.dismissAllowingStateLoss()
-                                            appSheet = AppSheet(item, AppExtras())
+                                            appSheet = AppSheet(item, AppExtras(item.packageName))
                                             appSheet?.showNow(
                                                 parentFragmentManager,
                                                 "Package ${item.packageName}"

--- a/app/src/main/java/com/machiav3lli/backup/handler/WorkHandler.kt
+++ b/app/src/main/java/com/machiav3lli/backup/handler/WorkHandler.kt
@@ -497,7 +497,7 @@ class WorkHandler {
                             )
                             .addAction(
                                 R.drawable.ic_close,
-                                "Cancel all",
+                                appContext.getString(R.string.dialogCancelAll),
                                 cancelAllPendingIntent
                             )
                     } else {

--- a/app/src/main/java/com/machiav3lli/backup/handler/WorkHandler.kt
+++ b/app/src/main/java/com/machiav3lli/backup/handler/WorkHandler.kt
@@ -356,11 +356,11 @@ class WorkHandler {
                                     running++
                                     val shortPackageName =
                                         packageName
-                                            ?.replace(Regex("""\bcom\b"""), "c")
-                                            ?.replace(Regex("""\borg\b"""), "o")
-                                            ?.replace(Regex("""\bandroid\b"""), "a")
-                                            ?.replace(Regex("""\bgoogle\b"""), "g")
-                                            ?.replace(Regex("""\bproviders\b"""), "p")
+                                            ?.replace(Regex("""\bcom\b"""), "C")
+                                            ?.replace(Regex("""\borg\b"""), "O")
+                                            ?.replace(Regex("""\bandroid\b"""), "A")
+                                            ?.replace(Regex("""\bgoogle\b"""), "G")
+                                            ?.replace(Regex("""\bproviders\b"""), "P")
                                     if (!packageName.isNullOrEmpty() and !operation.isNullOrEmpty())
                                         bigText +=
                                             "<p>" +

--- a/app/src/main/java/com/machiav3lli/backup/items/Package.kt
+++ b/app/src/main/java/com/machiav3lli/backup/items/Package.kt
@@ -22,6 +22,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import com.machiav3lli.backup.BACKUP_DATE_TIME_FORMATTER
 import com.machiav3lli.backup.BACKUP_INSTANCE_PROPERTIES
+import com.machiav3lli.backup.OABX
 import com.machiav3lli.backup.dbs.entity.AppInfo
 import com.machiav3lli.backup.dbs.entity.Backup
 import com.machiav3lli.backup.dbs.entity.SpecialInfo
@@ -53,7 +54,7 @@ class Package {
     ) {
         packageName = appInfo.packageName
         this.packageInfo = appInfo
-        getAppBackupRoot(context)
+        getAppBackupRoot()
         if (appInfo.installed) refreshStorageStats(context)
         updateBackupList(backups)
     }
@@ -65,7 +66,7 @@ class Package {
     ) {
         packageName = specialInfo.packageName
         this.packageInfo = specialInfo
-        getAppBackupRoot(context)
+        getAppBackupRoot()
         updateBackupList(backups)
     }
 
@@ -76,7 +77,7 @@ class Package {
     ) {
         packageName = packageInfo.packageName
         this.packageInfo = AppInfo(context, packageInfo)
-        getAppBackupRoot(context)
+        getAppBackupRoot()
         refreshStorageStats(context)
         updateBackupList(backups)
     }
@@ -158,7 +159,7 @@ class Package {
         if (packageBackupDir == null) StorageFile.invalidateCache {
             it.contains(backupDir.name ?: packageName)
         }
-        getAppBackupRoot(context)?.listFiles()
+        getAppBackupRoot()?.listFiles()
             ?.filter(StorageFile::isPropertyFile)
             ?.forEach { propFile ->
                 try {
@@ -189,17 +190,16 @@ class Package {
         StorageLocationNotConfiguredException::class
     )
     fun getAppBackupRoot(
-        context: Context,
         create: Boolean = false,
         packageName: String = this.packageName
     ): StorageFile? = when {
         packageBackupDir != null && packageBackupDir?.exists() == true -> packageBackupDir
         create -> {
-            packageBackupDir = context.getBackupDir().ensureDirectory(packageName)
+            packageBackupDir = OABX.context.getBackupDir().ensureDirectory(packageName)
             packageBackupDir
         }
         else -> {
-            packageBackupDir = context.getBackupDir().findFile(packageName)
+            packageBackupDir = OABX.context.getBackupDir().findFile(packageName)
             packageBackupDir
         }
     }

--- a/app/src/main/java/com/machiav3lli/backup/items/StorageFile.kt
+++ b/app/src/main/java/com/machiav3lli/backup/items/StorageFile.kt
@@ -80,6 +80,7 @@ open class StorageFile {
                                 // NOTE: lockups occur in emulator (or A12?) for certain paths
                                 // e.g. /storage/emulated/$user
                                 val possiblePaths = listOf(
+                                    "/mnt/media_rw/$storage/$subpath",
                                     "/mnt/pass_through/$user/$storage/$subpath",
                                     "/mnt/runtime/full/$storage/$subpath",
                                     "/mnt/runtime/default/$storage/$subpath",
@@ -87,7 +88,6 @@ open class StorageFile {
                                     // lockups! primary links to /storage/emulated/$user and all self etc.
                                     //"/storage/$storage/$subpath",
                                     //"/storage/self/$storage/$subpath",
-                                    //"/mnt/media_rw/$storage/$subpath",
                                     //"/mnt/runtime/default/self/$storage/$subpath"
                                     //"/mnt/user/$user/$storage/$subpath",
                                     //"/mnt/user/$user/self/$storage/$subpath",

--- a/app/src/main/java/com/machiav3lli/backup/services/CommandReceiver.kt
+++ b/app/src/main/java/com/machiav3lli/backup/services/CommandReceiver.kt
@@ -26,11 +26,10 @@ class CommandReceiver : //TODO hg42 how to maintain security?
         Timber.i("Command: command $command")
         when (command) {
             ACTION_CANCEL -> {
-                intent.getStringExtra("name")?.let { batchName ->
-                    Timber.d("################################################### command intent cancel -------------> name=$batchName")
-                    OABX.activity?.showToast("$command $batchName")
-                    OABX.work.cancel(batchName)
-                }
+                val batchName = intent.getStringExtra("name")
+                Timber.d("################################################### command intent cancel -------------> name=$batchName")
+                OABX.activity?.showToast("$command $batchName")
+                OABX.work.cancel(batchName)
             }
             ACTION_SCHEDULE -> {
                 intent.getStringExtra("name")?.let { name ->
@@ -69,7 +68,7 @@ class CommandReceiver : //TODO hg42 how to maintain security?
                 }
             }
             ACTION_CRASH -> {
-                throw Exception("this is an unknown exception sent from command intent")
+                throw Exception("this is a crash via command intent")
             }
             null -> {
                 // ignore?

--- a/app/src/main/java/com/machiav3lli/backup/services/PackageUnInstalledReceiver.kt
+++ b/app/src/main/java/com/machiav3lli/backup/services/PackageUnInstalledReceiver.kt
@@ -22,6 +22,7 @@ import android.content.Context
 import android.content.Intent
 import com.machiav3lli.backup.dbs.ODatabase
 import com.machiav3lli.backup.dbs.entity.AppInfo
+import com.machiav3lli.backup.items.StorageFile
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -34,6 +35,7 @@ class PackageUnInstalledReceiver : BroadcastReceiver() {
         val packageName =
             intent.data?.let { if (it.scheme == "package") it.schemeSpecificPart else null }
         if (packageName != null) {
+            StorageFile.invalidateCache { it.contains(packageName) }
             when (intent.action.orEmpty()) {
                 Intent.ACTION_PACKAGE_ADDED -> {
                     context.packageManager.getPackageInfo(packageName, 0)?.let { packageInfo ->

--- a/app/src/main/java/com/machiav3lli/backup/tasks/AppActionWork.kt
+++ b/app/src/main/java/com/machiav3lli/backup/tasks/AppActionWork.kt
@@ -255,6 +255,7 @@ class AppActionWork(val context: Context, workerParams: WorkerParameters) :
             batchName: String
         ) = OneTimeWorkRequest.Builder(AppActionWork::class.java)
             .addTag("name:$batchName")
+            .addTag("package:$packageName")
             .setInputData(
                 workDataOf(
                     "packageName" to packageName,

--- a/app/src/main/java/com/machiav3lli/backup/tasks/AppActionWork.kt
+++ b/app/src/main/java/com/machiav3lli/backup/tasks/AppActionWork.kt
@@ -132,7 +132,7 @@ class AppActionWork(val context: Context, workerParams: WorkerParameters) :
                                             context, this,
                                             shellHandler, pi,
                                             selectedMode, it,
-                                            it.getBackupInstanceFolder(pi.getAppBackupRoot(context))
+                                            it.getBackupInstanceFolder(pi.getAppBackupRoot())
                                         )
                                     }
                                 }

--- a/app/src/main/java/com/machiav3lli/backup/tasks/AppActionWork.kt
+++ b/app/src/main/java/com/machiav3lli/backup/tasks/AppActionWork.kt
@@ -30,8 +30,8 @@ import androidx.work.CoroutineWorker
 import androidx.work.Data
 import androidx.work.ForegroundInfo
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkInfo
-import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import com.machiav3lli.backup.MODE_UNSET
@@ -49,6 +49,7 @@ import com.machiav3lli.backup.handler.getSpecial
 import com.machiav3lli.backup.handler.showNotification
 import com.machiav3lli.backup.items.ActionResult
 import com.machiav3lli.backup.items.Package
+import com.machiav3lli.backup.services.CommandReceiver
 import timber.log.Timber
 
 class AppActionWork(val context: Context, workerParams: WorkerParameters) :
@@ -67,9 +68,9 @@ class AppActionWork(val context: Context, workerParams: WorkerParameters) :
 
     override suspend fun doWork(): Result {
 
-        setOperation("...")
+        var result: ActionResult? = null
 
-        val selectedMode = inputData.getInt("selectedMode", MODE_UNSET)
+        setOperation("...")
 
         var message =
             "------------------------------------------------------------ Work: $batchName $packageName"
@@ -78,10 +79,11 @@ class AppActionWork(val context: Context, workerParams: WorkerParameters) :
         }
         Timber.i(message)
 
-        if (OABX.prefFlag(PREFS_USEFOREGROUND, true))
-            setForeground(createForegroundInfo())
+        val selectedMode = inputData.getInt("selectedMode", MODE_UNSET)
 
-        var result: ActionResult? = null
+        if (OABX.prefFlag(PREFS_USEFOREGROUND, true))
+            setForeground(getForegroundInfo())
+
         var packageItem: Package? = null
 
         try {
@@ -204,15 +206,26 @@ class AppActionWork(val context: Context, workerParams: WorkerParameters) :
     }
 
 
-    private fun createForegroundInfo(): ForegroundInfo {
+    override suspend fun getForegroundInfo(): ForegroundInfo {
         val contentPendingIntent = PendingIntent.getActivity(
             context, 0,
             Intent(context, MainActivityX::class.java),
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         )
 
-        val cancelIntent = WorkManager.getInstance(applicationContext)
-            .createCancelPendingIntent(id) // TODO [hg42: is the comment still valid?] causing crash on targetSDK 31 on A12, go back to targetSDK 30 for now and wait update on WorkManager's side
+        //val cancelPendingIntent = WorkManager.getInstance(applicationContext)
+        //    .createCancelPendingIntent(id) // TODO [hg42: is the comment still valid?] causing crash on targetSDK 31 on A12, go back to targetSDK 30 for now and wait update on WorkManager's side
+        val cancelAllIntent =
+            Intent(OABX.context, CommandReceiver::class.java).apply {
+                action = "cancel"
+                //putExtra("name", "")
+            }
+        val cancelAllPendingIntent = PendingIntent.getBroadcast(
+            OABX.context,
+            "<ALL>".hashCode(),
+            cancelAllIntent,
+            PendingIntent.FLAG_IMMUTABLE
+        )
 
         createNotificationChannel()
 
@@ -229,7 +242,7 @@ class AppActionWork(val context: Context, workerParams: WorkerParameters) :
             .setContentIntent(contentPendingIntent)
             .setPriority(NotificationCompat.PRIORITY_MAX)
             .setCategory(NotificationCompat.CATEGORY_SERVICE)
-            .addAction(R.drawable.ic_close, context.getString(R.string.dialogCancel), cancelIntent)
+            .addAction(R.drawable.ic_close, context.getString(R.string.dialogCancelAll), cancelAllPendingIntent)
             .build()
 
         return ForegroundInfo(this.notificationId + 1, notification)
@@ -253,20 +266,28 @@ class AppActionWork(val context: Context, workerParams: WorkerParameters) :
             backupBoolean: Boolean,
             notificationId: Int,
             batchName: String
-        ) = OneTimeWorkRequest.Builder(AppActionWork::class.java)
-            .addTag("name:$batchName")
-            .addTag("package:$packageName")
-            .setInputData(
-                workDataOf(
-                    "packageName" to packageName,
-                    "selectedMode" to mode,
-                    "backupBoolean" to backupBoolean,
-                    "notificationId" to notificationId,
-                    "batchName" to batchName,
-                    "operation" to "..."
+        ): OneTimeWorkRequest {
+            val builder = OneTimeWorkRequest.Builder(AppActionWork::class.java)
+
+            builder
+                .addTag("name:$batchName")
+                .addTag("package:$packageName")
+                .setInputData(
+                    workDataOf(
+                        "packageName" to packageName,
+                        "selectedMode" to mode,
+                        "backupBoolean" to backupBoolean,
+                        "notificationId" to notificationId,
+                        "batchName" to batchName,
+                        "operation" to "..."
+                    )
                 )
-            )
-            .build()
+
+            if (OABX.prefFlag("useExpedited", true))
+                builder.setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+
+            return builder.build()
+        }
 
         fun getOutput(t: WorkInfo): Triple<Boolean, String, String> {
             val succeeded = t.outputData.getBoolean("succeeded", false)

--- a/app/src/main/java/com/machiav3lli/backup/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/machiav3lli/backup/viewmodels/MainViewModel.kt
@@ -102,7 +102,7 @@ class MainViewModel(
             try {
                 appPackage?.apply {
                     val new =
-                        Package(appContext, packageName, appPackage.getAppBackupRoot(appContext))
+                        Package(appContext, packageName, appPackage.getAppBackupRoot())
                     new.refreshBackupList(appContext)
                     if (!isSpecial) db.appInfoDao.update(new.packageInfo as AppInfo)
                     db.backupDao.updateList(new)

--- a/app/src/main/java/com/machiav3lli/backup/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/machiav3lli/backup/viewmodels/MainViewModel.kt
@@ -33,7 +33,6 @@ import com.machiav3lli.backup.handler.toPackageList
 import com.machiav3lli.backup.handler.updateAppInfoTable
 import com.machiav3lli.backup.handler.updateBackupTable
 import com.machiav3lli.backup.items.Package
-import com.machiav3lli.backup.items.StorageFile
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -171,6 +171,7 @@
     <string name="restart_dialog">The app seems needing to be restarted</string>
     <string name="dialogOK">OK</string>
     <string name="dialogCancel">Cancel</string>
+    <string name="dialogCancelAll">Cancel all</string>
     <string name="dialogYes">Yes</string>
     <string name="dialogNo">No</string>
     <string name="dialogSave">Save</string>

--- a/app/src/main/res/xml/preferences_advanced.xml
+++ b/app/src/main/res/xml/preferences_advanced.xml
@@ -76,12 +76,6 @@
 
         <androidx.preference.CheckBoxPreference
             android:defaultValue="true"
-            android:key="useForeground"
-            android:summary="use forground notifications to ensure app keeps runninig (if wakelock isn't enough)"
-            android:title="useForeground" />
-
-        <androidx.preference.CheckBoxPreference
-            android:defaultValue="true"
             android:key="pauseApps"
             android:summary="pause apps during backups and restores to avoid inconsistent backups caused by ongoing file changes or other conflicts"
             android:title="pauseApps" />
@@ -179,6 +173,18 @@
             android:title="refreshAppInfoTimeout"
             app:min="0"
             app:showSeekBarValue="true" />
+
+        <androidx.preference.CheckBoxPreference
+            android:defaultValue="false"
+            android:key="useForeground"
+            android:summary="use forground notifications to ensure app keeps running (if wakelock isn't enough)"
+            android:title="useForeground" />
+
+        <androidx.preference.CheckBoxPreference
+            android:defaultValue="true"
+            android:key="useExpedited"
+            android:summary="use work manager forground to overcome 10 minute job timeouts"
+            android:title="useExpedited" />
 
     </androidx.preference.PreferenceCategory>
 


### PR DESCRIPTION
* add useExpedited, fixes killing jobs after 10 minutes
  * doWork is limited to 10 min at least in pre A12 (when JobScheduler is used internally)
  * the only way to fix this for all cases seems to be using the setExpedited function (foreground is not enough)
  * see the new NOTES.md
  
* add package name as tag to see it in logcat messages
  * we only see the tags in logcat
  * could also be used to select work
  
* getAppBackupRoot: make sure the context is always the app context
  * for me it doesn't make sense to shuffle the context through all functions if all we want is the app context
  * it also makes clear that the app context is used not some other context from "dubious" sources

* use big letters for abbreviations
  * abbreviations are now shown as big letters, e.g. com.google.android -> C.G.A
  
* fix cancel in foreground notification
  * the CommandReceiver and the intent did not agree how to handle cancel all

* allow /mnt/media_rw/ again
  * I was wrong in thinking this directory would freeze, the reason was a full sdcard
  
* fix toast duration on catchUncaughtExceptions (make it very long)
  * repeat the toast several times and wait in the loop **and** the surrounding scope

* fix AppSheet missing packageName in AppExtras
  * from my tests there is no need to update the whole list when only the package changed