### PR TITLE
fix freezing on com.google.android.providers.* etc., ignore empty string permissions (pm grant p.k.g "" = error)

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/actions/BaseAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/BaseAppAction.kt
@@ -151,15 +151,15 @@ abstract class BaseAppAction protected constructor(
         val ignoredPackages = ("""(?x)
             # complete matches
               android
-            | com\.android\.shell
-            | com\.android\.systemui
-            | com\.android\.externalstorage
-            | com\.android\.mtp
-            | com\.android\.providers\.downloads\.ui
-            | com\.google\.android\.gms
-            | com\.google\.android\.gsf
             # pattern matches
-            | com\.android\.providers\.media\b.*
+            | .*\.android\.shell
+            | .*\.android\.systemui
+            | .*\.android\.externalstorage
+            | .*\.android\.mtp
+            | .*\.android\.providers\.downloads\.ui
+            | .*\.android\.gms
+            | .*\.android\.gsf
+            | .*\.android\.providers\.media\b.*
             # program values
             | """ + Regex.escape(BuildConfig.APPLICATION_ID) + """
             """).toRegex()
@@ -167,15 +167,16 @@ abstract class BaseAppAction protected constructor(
         val doNotStop = ("""(?x)
             # complete matches
               android
-            | com\.android\.shell
-            | com\.android\.systemui
-            | com\.android\.externalstorage
-            | com\.android\.mtp
-            | com\.android\.providers\.downloads\.ui
-            | com\.google\.android\.gms
-            | com\.google\.android\.gsf
             # pattern matches
-            | com\.android\.providers\.media\b.*
+            | .*\.android\.shell
+            | .*\.android\.systemui
+            | .*\.android\.externalstorage
+            | .*\.android\.mtp
+            | .*\.android\.providers\.downloads\.ui
+            | .*\.android\.gms
+            | .*\.android\.gsf
+            | .*\.android\.providers\.media\b.*
+            | .*\.android\.providers\..*
             # program values
             | """ + Regex.escape(BuildConfig.APPLICATION_ID) + """
             """).toRegex()

--- a/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
@@ -294,6 +294,7 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
                 )
             )
             // If split apk resources exist, install them afterwards (order does not matter)
+            //TODO hg42 gather results, eventually ignore grant errors, use script?
             if (splitApksInBackup.isNotEmpty()) {
                 splitApksInBackup.forEach {
                     sb.append(" ; ").append(
@@ -306,7 +307,11 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
                 }
             }
             if (!context.isRestoreAllPermissions)
-                backup.permissions.forEach { p -> sb.append(" ; pm grant ${backup.packageName} $p") }
+                backup.permissions
+                    .filterNot { it.isEmpty() }
+                    .forEach {
+                            p -> sb.append(" ; pm grant ${backup.packageName} $p")
+                    }
 
             val command = sb.toString()
             runAsRoot(command)


### PR DESCRIPTION
* freezing on com.google.android.*

  Some packages with the pattern `com.android.XXX` are excluded from STOP signals and pmSuspend or ignored completely.
  This patch prevents the case when e.g. on the Android emulator and some GSIs and probably some Google devices, such packages are replaced by similar `com.google.android.XXX` packages, which are now excluded, too. I generally replaced a wildcard `com.android.XXX` by `*.android.XXX` to be on the safe side.
  Like Google other vendors could also get the idea and use their own name in the package name and it could also be `org.*` or similar.
  
* ignore empty permissions (pm grant p.k.g "" = error)
  
  This will help, when we get permissions with an empty name (not to confuse with an empty list, which is already handled).
  Note, that this prevents an error, but the cause for such an empty permission name is still existing. Latest report may suggest that it happens when Magisk isn't installed fully ("fully", because NB doesn't complain of not getting root, so root is there in some way, may be built into the ROM, or may be a weaker version, or may be Magisk needs to complete it's install).