### PR TITLE
add ensureBackupList to fix backupLists, also make Packages singletons by cache

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/handler/BackendController.kt
+++ b/app/src/main/java/com/machiav3lli/backup/handler/BackendController.kt
@@ -195,7 +195,9 @@ fun List<AppInfo>.toPackageList(
         }
             .mapNotNull {
                 try {
-                    Package(context, it, backupMap[it.packageName].orEmpty())
+                    Package.get(it.packageName) {
+                        Package(context, it, backupMap[it.packageName].orEmpty())
+                    }
                 } catch (e: AssertionError) {
                     Timber.e("Could not create Package for ${it}: $e")
                     null
@@ -239,7 +241,9 @@ fun List<AppInfo>.toPackageList(
                 }
                 .mapNotNull {
                     try {
-                        Package(context, it.name, it, backupMap[it.name].orEmpty())
+                        Package.get(it.name ?: "") {
+                            Package(context, it.name, it, backupMap[it.name].orEmpty())
+                        }
                     } catch (e: AssertionError) {
                         Timber.e("Could not process backup folder for uninstalled application in ${it.name}: $e")
                         null

--- a/app/src/main/java/com/machiav3lli/backup/items/Package.kt
+++ b/app/src/main/java/com/machiav3lli/backup/items/Package.kt
@@ -45,6 +45,7 @@ class Package {
     private var packageBackupDir: StorageFile? = null
     var storageStats: StorageStats? = null
 
+    private var backupListDirty = true
     private var backupListState = mutableStateOf(listOf<Backup>())
     private var backupList by backupListState
 
@@ -185,6 +186,12 @@ class Package {
                     LogsHandler.unhandledException(e, message)
                 }
             }
+        backupListDirty = false
+    }
+
+    fun ensureBackupList() {
+        if (backupListDirty)
+            refreshBackupList()
     }
 
     @Throws(

--- a/app/src/main/java/com/machiav3lli/backup/ui/compose/item/BatchPackageItem.kt
+++ b/app/src/main/java/com/machiav3lli/backup/ui/compose/item/BatchPackageItem.kt
@@ -60,6 +60,7 @@ fun BatchPackageItem(
             }
         )
     }
+    packageItem.ensureBackupList()
 
     OutlinedCard(
         modifier = Modifier,

--- a/app/src/main/java/com/machiav3lli/backup/ui/compose/item/MainPackageItem.kt
+++ b/app/src/main/java/com/machiav3lli/backup/ui/compose/item/MainPackageItem.kt
@@ -41,6 +41,7 @@ fun MainPackageItem(
             else "android.resource://${packageItem.packageName}/${packageItem.packageInfo.icon}"
         )
     }
+    packageItem.ensureBackupList()
 
     OutlinedCard(
         modifier = Modifier,

--- a/app/src/main/java/com/machiav3lli/backup/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/machiav3lli/backup/viewmodels/MainViewModel.kt
@@ -131,8 +131,9 @@ class MainViewModel(
             val appPackage = packageList.value?.find { it.packageName == packageName }
             try {
                 appPackage?.apply {
-                    val new =
+                    val new = Package.get(packageName) {
                         Package(appContext, packageName, appPackage.getAppBackupRoot())
+                    }
                     new.refreshBackupList() //TODO hg42 such optimizations should be encapsulated (in Package)
                     if (!isSpecial) db.appInfoDao.update(new.packageInfo as AppInfo)
                     db.backupDao.updateList(new)


### PR DESCRIPTION
* use ensureBackupList in all Package-Recyclers places to ensure backupList is loaded
  * it's lean because only shown items are refreshed
  * it ensures that a user always sees correct items
  * AppSheet works from such an item, too

* ensure that a Package object for a packageName is always the same (cache)