### PR TITLE
use "find | xargs ls" to recursively scan a file tree

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/RestoreAppAction.kt
@@ -115,14 +115,17 @@ open class RestoreAppAction(context: Context, work: AppActionWork?, shell: Shell
                 )
             } catch (e: RestoreFailedException) {
                 // Unwrap issues with shell commands so users know what command ran and what was the issue
-                val message: String =
-                    if (e.cause != null && e.cause is ShellCommandFailedException) {
-                        val commandList = e.cause.commands.joinToString("; ")
-                        "Shell command failed: ${commandList}\n${
-                            extractErrorMessage(e.cause.shellResult)
-                        }"
-                    } else {
-                        "${e.javaClass.simpleName}: ${e.message}"
+                val message =
+                    when (val cause = e.cause) {
+                        is ShellCommandFailedException -> {
+                            val commandList = cause.commands.joinToString("; ")
+                            "Shell command failed: ${commandList}\n${
+                                extractErrorMessage(cause.shellResult)
+                            }"
+                        }
+                        else -> {
+                            "${e.javaClass.simpleName}: ${e.message}"
+                        }
                     }
                 return ActionResult(app, null, message, false)
             } catch (e: CryptoSetupException) {

--- a/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.kt
+++ b/app/src/main/java/com/machiav3lli/backup/activities/MainActivityX.kt
@@ -85,7 +85,7 @@ class MainActivityX : BaseActivity() {
         if (OABX.prefFlag(PREFS_CATCHUNCAUGHT, false)) {
             Thread.setDefaultUncaughtExceptionHandler { _, e ->
                 try {
-                    val maxCrashLines = OABX.prefInt(PREFS_MAXCRASHLINES, 100)
+                    val maxCrashLines = OABX.prefInt(PREFS_MAXCRASHLINES, 50)
                     LogsHandler.unhandledException(e)
                     LogsHandler(context).writeToLogFile(
                         "uncaught exception happened:\n\n" +
@@ -95,19 +95,24 @@ class MainActivityX : BaseActivity() {
                                     "logcat -d -t $maxCrashLines --pid=${Process.myPid()}"  // -d = dump and exit
                                 ).out.joinToString("\n")
                     )
-                    val longToastTime = 3500
-                    val showTime = 21 * 1000
+                    val longToastTime = 3000
+                    val showTime = 12000
                     object : Thread() {
                         override fun run() {
                             Looper.prepare()
                             repeat(showTime / longToastTime) {
                                 Toast.makeText(
                                     context,
-                                    "Uncaught Exception\n${e.message}\n${e.cause}\nrestarting application...",
+                                    "Uncaught Exception\n${e.message ?: ""}\n${e.cause ?: ""}",
                                     Toast.LENGTH_LONG
                                 ).show()
                                 sleep(longToastTime.toLong())
                             }
+                            Toast.makeText(
+                                context,
+                                "restarting application...",
+                                Toast.LENGTH_LONG
+                            ).show()
                             Looper.loop()
                         }
                     }.start()

--- a/app/src/main/java/com/machiav3lli/backup/fragments/AppSheet.kt
+++ b/app/src/main/java/com/machiav3lli/backup/fragments/AppSheet.kt
@@ -728,14 +728,14 @@ class AppSheet(val appInfo: Package, var appExtras: AppExtras) :
         } catch (e: ShellCommands.ShellActionFailedException) {
             // Not a critical issue
             val errorMessage: String =
-                when (e.cause) {
+                when (val cause = e.cause) {
                     is ShellHandler.ShellCommandFailedException -> {
-                        e.cause.shellResult.err.joinToString(
+                        cause.shellResult.err.joinToString(
                             " "
                         )
                     }
                     else -> {
-                        e.cause?.message ?: "unknown error"
+                        cause?.message ?: "unknown error"
                     }
                 }
             Timber.w("Cache couldn't be deleted: $errorMessage")

--- a/app/src/main/java/com/machiav3lli/backup/handler/ShellCommands.kt
+++ b/app/src/main/java/com/machiav3lli/backup/handler/ShellCommands.kt
@@ -37,12 +37,13 @@ class ShellCommands(private var users: List<String>?) {
             users = getUsers()
         } catch (e: ShellActionFailedException) {
             users = null
-            var error: String? = null
-            // instanceOf returns false for nulls, so need to check if null
-            if (e.cause is ShellCommandFailedException) {
-                error = e.cause.shellResult.err.joinToString(" ")
-            }
-            Timber.e("Could not load list of users: ${e}${if (error != null) " : $error" else ""}")
+            var error =
+                when (val cause = e.cause) {
+                    is ShellCommandFailedException ->
+                        " : ${cause.shellResult.err.joinToString(" ")}"
+                    else -> ""
+                }
+            Timber.e("Could not load list of users: ${e}$error")
         }
         multiuserEnabled = !users.isNullOrEmpty() && users?.size ?: 1 > 1
     }

--- a/app/src/main/java/com/machiav3lli/backup/items/Package.kt
+++ b/app/src/main/java/com/machiav3lli/backup/items/Package.kt
@@ -253,16 +253,24 @@ class Package {
         )
         try {
             backup.getBackupInstanceFolder(packageBackupDir)?.deleteRecursive()
+        } catch (e: Throwable) {
+            LogsHandler.unhandledException(e, backup.packageName)
+        }
+        try {
             packageBackupDir?.findFile(propertiesFileName)?.delete() ?: packageBackupDir?.findFile(
                 propertiesFileNameOld
             )?.delete()
         } catch (e: Throwable) {
             LogsHandler.unhandledException(e, backup.packageName)
         }
-        backupList = backupList.toList() - backup
-        if (backupList.size == 0) {
-            packageBackupDir?.deleteRecursive()
-            packageBackupDir = null
+        try {
+            backupList = backupList.toList() - backup
+            if (backupList.size == 0) {
+                packageBackupDir?.deleteRecursive()
+                packageBackupDir = null
+            }
+        } catch (e: Throwable) {
+            LogsHandler.unhandledException(e, backup.packageName)
         }
     }
 

--- a/app/src/main/java/com/machiav3lli/backup/tasks/BackupActionTask.kt
+++ b/app/src/main/java/com/machiav3lli/backup/tasks/BackupActionTask.kt
@@ -17,12 +17,14 @@
  */
 package com.machiav3lli.backup.tasks
 
+import com.machiav3lli.backup.OABX
 import com.machiav3lli.backup.activities.MainActivityX
 import com.machiav3lli.backup.fragments.AppSheet
 import com.machiav3lli.backup.handler.BackupRestoreHelper
 import com.machiav3lli.backup.handler.ShellHandler
 import com.machiav3lli.backup.items.ActionResult
 import com.machiav3lli.backup.items.Package
+import com.machiav3lli.backup.utils.showToast
 
 class BackupActionTask(
     appInfo: Package, oAndBackupX: MainActivityX, shellHandler: ShellHandler, backupMode: Int,
@@ -37,9 +39,17 @@ class BackupActionTask(
         if (mainActivityX == null || mainActivityX.isFinishing) {
             return ActionResult(app, null, "", false)
         }
+        val startTime = System.currentTimeMillis()
+
         notificationId = System.currentTimeMillis().toInt()
         publishProgress()
+
         result = BackupRestoreHelper.backup(mainActivityX, null, shellHandler, app, mode)
+
+        val afterTime = System.currentTimeMillis()
+        OABX.activity?.showToast(
+            "backup: ${app.packageName}: ${((afterTime - startTime) / 1000 + 0.5).toInt()} sec"
+        )
         return result
     }
 }

--- a/app/src/main/res/xml/preferences_advanced.xml
+++ b/app/src/main/res/xml/preferences_advanced.xml
@@ -154,6 +154,12 @@
             android:title="allowShadowingDefault" />
 
         <androidx.preference.CheckBoxPreference
+            android:defaultValue="true"
+            android:key="useFindLs"
+            android:summary="use 'find ... | xargs ... ls ...' for recursive FileInfo collection"
+            android:title="useFindLs" />
+
+        <androidx.preference.CheckBoxPreference
             android:defaultValue="false"
             android:key="catchUncaughtException"
             android:summary="unexpected exceptions are caught and output to logcat and app is restarted [needs reboot]"

--- a/app/src/main/res/xml/preferences_advanced.xml
+++ b/app/src/main/res/xml/preferences_advanced.xml
@@ -160,6 +160,12 @@
             android:title="useFindLs" />
 
         <androidx.preference.CheckBoxPreference
+            android:defaultValue="true"
+            android:key="useAssembleFileListOneStep"
+            android:summary="(tarapi) collect whole tree in one step"
+            android:title="useAssembleFileListOneStep" />
+
+        <androidx.preference.CheckBoxPreference
             android:defaultValue="false"
             android:key="catchUncaughtException"
             android:summary="unexpected exceptions are caught and output to logcat and app is restarted [needs reboot]"


### PR DESCRIPTION
Scan a whole tree instead of one command for each directory.

This works nice, but doesn't help as much as I thought for tarapi speed.

Could eventually be used for tarcmd if we need more sophisticated file filtering.

Additionally it could make tarapi and tarcmd more compatible according to filtering.

Also, some smaller things...