### PR TITLE
select utilBox by score (version based for now, may be real tests later)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -131,6 +131,7 @@ dependencies {
     implementation("com.github.topjohnwu.libsu:core:$libsu")
     implementation("com.github.topjohnwu.libsu:io:$libsu")
     //implementation("com.github.topjohnwu.libsu:busybox:$libsu")
+    implementation("com.vdurmont:semver4j:3.1.0")
     //implementation("com.github.tony19:named-regexp:0.2.6") // regex named groups
 
     // UI

--- a/app/src/main/java/com/machiav3lli/backup/actions/BaseAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/BaseAppAction.kt
@@ -26,6 +26,7 @@ import com.machiav3lli.backup.PREFS_PMSUSPEND
 import com.machiav3lli.backup.handler.LogsHandler
 import com.machiav3lli.backup.handler.ShellHandler
 import com.machiav3lli.backup.handler.ShellHandler.Companion.runAsRoot
+import com.machiav3lli.backup.handler.ShellHandler.Companion.utilBox
 import com.machiav3lli.backup.handler.ShellHandler.Companion.utilBoxQ
 import com.machiav3lli.backup.handler.ShellHandler.ShellCommandFailedException
 import com.machiav3lli.backup.tasks.AppActionWork
@@ -145,8 +146,8 @@ abstract class BaseAppAction protected constructor(
             "cache",
             "trash",
             ".thumbnails",
-            if (OABX.minSDK(Build.VERSION_CODES.R)) "..*" else null
-        )
+            if (utilBox.hasBugDotDotDir) "..*" else null
+        ).filterNotNull()
 
         val ignoredPackages = ("""(?x)
             # complete matches

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.2.0")
+        classpath("com.android.tools.build:gradle:7.2.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21")
     }
 }


### PR DESCRIPTION
algorithm is tested, but needs prove for the version ranges:
* what is our first tested version? (0.8.0 for now)
* does 0.8.7 work? (installable as toybox-ext via Magisk module)

In the api32 emulator the installed toybox-ext isn't working for some reason. It looks like it cannot find it's own path. Starting `/system/xbin/toybox-ext` always gives an error about it's realpath.
Please report if you don't have this in the emulator (using Magisk and the toybox(ext) module).