### PR TITLE
automatically adapt `--mount-master` option to what libsu detected

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/actions/BackupAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/BackupAppAction.kt
@@ -501,7 +501,7 @@ open class BackupAppAction(context: Context, work: AppActionWork?, shell: ShellH
             if (context.getDefaultSharedPreferences().getBoolean(PREFS_EXCLUDECACHE, true)) {
                 options += " --exclude ${quote(excludeCache)}"
             }
-            var suOptions = "--mount-master"
+            var suOptions = if(ShellHandler.isMountMaster) "--mount-master" else ""
 
             val cmd = "su $suOptions -c sh ${quote(tarScript)} create $utilBoxQ $options ${
                 quote(sourcePath)

--- a/app/src/main/java/com/machiav3lli/backup/handler/ShellHandler.kt
+++ b/app/src/main/java/com/machiav3lli/backup/handler/ShellHandler.kt
@@ -26,6 +26,7 @@ import com.machiav3lli.backup.utils.BUFFER_SIZE
 import com.machiav3lli.backup.utils.FileUtils.translatePosixPermissionToMode
 import com.machiav3lli.backup.utils.showToast
 import com.topjohnwu.superuser.Shell
+import com.topjohnwu.superuser.Shell.ROOT_MOUNT_MASTER
 import com.topjohnwu.superuser.io.SuRandomAccessFile
 import com.vdurmont.semver4j.Semver
 import timber.log.Timber
@@ -93,6 +94,10 @@ class ShellHandler {
                           .setTimeout(20)
                           //.setInitializers(BusyBoxInstaller::class.java)
         Shell.setDefaultBuilder(builder)
+        Shell.getShell()
+
+        Timber.i("is root         = ${Shell.rootAccess()}")
+        Timber.i("is mount-master = $isMountMaster")
 
         val boxes = mutableListOf<UtilBox>()
         try {
@@ -563,6 +568,8 @@ class ShellHandler {
             "toybox_vendor",
             "toybox",
         )
+
+        val isMountMaster get() = Shell.getShell().status >= ROOT_MOUNT_MASTER
 
         var utilBox: UtilBox = UtilBox()
         val utilBoxQ get() = utilBox.quote()


### PR DESCRIPTION
libsu tries three steps and takes the first that works:
* `su --mount-master`
* `su`
* `sh`

External commands (like tar) that cannot use the normal libsu shell functions (which collect output lines into an array) must add `--mount-master` by themselves.

**After this PR those commands only use `--mount-master` if libsu detected it before.**

Probably fixes #562, though it's still not clear if it would work without `--mount-master` functionality.
But at least it should then work like older OAndBackup* versions:
> Meanwhile the good-old oandbackup works.

`--mount-master` seems to be necessary for api30++, so it may work up to A10
> I now learned that su needs a --mount-master option on newer Android versions (API 30++).
> Otherwise the namespace of the OAndBackupX user id is totally different from that of any other app and even root doesn't see the files of other apps.