### PR TITLE
fix too wide exclusion list (allow com.mgoogle.android.gms)

### DIFF
--- a/app/src/main/java/com/machiav3lli/backup/actions/BaseAppAction.kt
+++ b/app/src/main/java/com/machiav3lli/backup/actions/BaseAppAction.kt
@@ -150,35 +150,29 @@ abstract class BaseAppAction protected constructor(
         ).filterNotNull()
 
         val ignoredPackages = ("""(?x)
-            # complete matches
               android
-            # pattern matches
-            | .*\.android\.shell
-            | .*\.android\.systemui
-            | .*\.android\.externalstorage
-            | .*\.android\.mtp
-            | .*\.android\.providers\.downloads\.ui
-            | .*\.android\.gms
-            | .*\.android\.gsf
-            | .*\.android\.providers\.media\b.*
-            # program values
+            | ^com\.(google\.)?android\.shell
+            | ^com\.(google\.)?android\.systemui
+            | ^com\.(google\.)?android\.externalstorage
+            | ^com\.(google\.)?android\.mtp
+            | ^com\.(google\.)?android\.providers\.downloads\.ui
+            | ^com\.(google\.)?android\.gms
+            | ^com\.(google\.)?android\.gsf
+            | ^com\.(google\.)?android\.providers\.media\b.*
             | """ + Regex.escape(BuildConfig.APPLICATION_ID) + """
             """).toRegex()
 
         val doNotStop = ("""(?x)
-            # complete matches
               android
-            # pattern matches
-            | .*\.android\.shell
-            | .*\.android\.systemui
-            | .*\.android\.externalstorage
-            | .*\.android\.mtp
-            | .*\.android\.providers\.downloads\.ui
-            | .*\.android\.gms
-            | .*\.android\.gsf
-            | .*\.android\.providers\.media\b.*
-            | .*\.android\.providers\..*
-            # program values
+            | ^com\.(google\.)?android\.shell
+            | ^com\.(google\.)?android\.systemui
+            | ^com\.(google\.)?android\.externalstorage
+            | ^com\.(google\.)?android\.mtp
+            | ^com\.(google\.)?android\.providers\.downloads\.ui
+            | ^com\.(google\.)?android\.gms
+            | ^com\.(google\.)?android\.gsf
+            | ^com\.(google\.)?android\.providers\.media\b.*
+            | ^com\.(google\.)?android\.providers\..*
             | """ + Regex.escape(BuildConfig.APPLICATION_ID) + """
             """).toRegex()
 


### PR DESCRIPTION
"Vanced microg" uses a package name com.mgoogle.android.gms that was matched by ignoredPackages.
The regex used patterns like .*.android.gms
Now it uses more explicit patterns like com.(google.)android.gms