### PR TITLE
Fix ScheduleService not being started after reboot

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.KILL_BACKGROUND_PROCESSES" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission
         android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
         tools:ignore="ScopedStorage" />
@@ -149,7 +150,13 @@
             android:name=".manager.services.CommandReceiver"
             android:exported="true" />
 
-        <receiver android:name=".manager.services.ScheduleReceiver" />
+        <receiver
+            android:name=".manager.services.ScheduleReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+         </receiver>
 
         <service
             android:name=".manager.services.ScheduleService"


### PR DESCRIPTION
This fixes the problem with scheduled backups not being started, but immediately being triggered after opening the app.

See most recent comments in #933 .

Tested on my self build crDroid (A15) on Xiaomi 11T Pro.

For htc-devices (and probably others) it might be needed to also add `com.htc.intent.action.QUICKBOOT_POWERON` and/or `android.intent.action.QUICKBOOT_POWERON` to the intent-filters.